### PR TITLE
Change links from AnalyticalGraphicsInc to CesiumGS

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Code of Conduct 
 
-One of Cesium's strengths is our community.  Our contributors and users are pushing the 3D geospatial field to amazing new levels.  We rely on an open, friendly, inclusive environment to facilitate this.  As such, we follow the [Contributor Covenant](http://contributor-covenant.org/)'s [Code of Conduct](http://contributor-covenant.org/version/1/4/code-of-conduct.md) to ensure a harassment-free experience in the Cesium community.  Any unacceptable behavior can be confidentially sent to the core team at pcozzi@agi.com.
+One of Cesium's strengths is our community.  Our contributors and users are pushing the 3D geospatial field to amazing new levels.  We rely on an open, friendly, inclusive environment to facilitate this.  As such, we follow the [Contributor Covenant](http://contributor-covenant.org/)'s [Code of Conduct](http://contributor-covenant.org/version/1/4/code-of-conduct.md) to ensure a harassment-free experience in the Cesium community.  Any unacceptable behavior can be confidentially sent to the core team at patrick@cesium.com.
 
-This applies to this repo, forum, twitter, and all channels, including all repos in the [AnalyticalGraphicsInc](https://github.com/AnalyticalGraphicsInc) GitHub organization.
+This applies to this repo, forum, twitter, and all channels, including all repos in the [CesiumGS](https://github.com/CesiumGS) GitHub organization.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 To add any schema or markdown updates to the 3D Tiles Specification PDF, take the following steps:
 
 1. Generate markdown property references from the schema.
-    * Run the [wetzel](https://github.com/AnalyticalGraphicsInc/wetzel) tool on the schema to generate markdown property reference on the schemas in the `specification/schema` directory.
+    * Run the [wetzel](https://github.com/CesiumGS/wetzel) tool on the schema to generate markdown property reference on the schemas in the `specification/schema` directory.
     * Paste the generated markdown in the corresponding section of `specification/README.md` or the `specification/TileFormats/<TILE_FORMAT>/README.md`.
 
 1. Generate a `.docx` file for each section.

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,6 +1,6 @@
 ## Who's using 3D Tiles?
 
-![](figures/ecosystem/composer.jpg) [Cesium ion](https://www.cesium.com/) converters | ![](figures/ecosystem/AGI.jpg) [Cesium](http://cesiumjs.org/) |
+![](figures/ecosystem/composer.jpg) [Cesium ion](https://cesium.com/) converters | ![](figures/ecosystem/AGI.jpg) [CesiumJS](https://cesium.com/cesiumjs/) |
 |:---:|:---:|
 ![](figures/ecosystem/Vricon.jpg) [Vricon](http://www.vricon.com/) | ![](figures/ecosystem/swisstopo.jpg) Federal Office of Topography <br/> [swisstopo](https://map.geo.admin.ch)  |
 ![](figures/ecosystem/BentleyContextCapture.jpg) [Bentley ContextCapture](https://www.linkedin.com/pulse/contextcapture-web-publishing-cesium-aude-camus) | ![](figures/ecosystem/microstation.jpg) [Bentley MicroStation](https://www.bentley.com/en/products/brands/microstation) (in progress) |
@@ -11,5 +11,5 @@
 ![](figures/ecosystem/sitesee.jpg) [SiteSee](http://www.sitesee.com.au/) (using three.js) | [Peaxy](https://peaxy.net/)  |
 ![](figures/ecosystem/virtualgis.jpg) [VirtualGIS](https://www.virtualgis.io/) | ![](figures/ecosystem/grandlyon.jpg) [LOPoCS ](https://github.com/Oslandia/lopocs) and [py3dtiles](https://github.com/Oslandia/py3dtiles)
 ![](figures/ecosystem/itowns.jpg) [iTowns 2](https://github.com/iTowns/itowns) | ![](figures/ecosystem/osm-cesium-3d-tiles.jpg) [osm-cesium-3d-tiles](https://github.com/kiselev-dv/osm-cesium-3d-tiles) |
-![](figures/ecosystem/geopipe.jpg) [geopipe](https://geopi.pe/) | ![](figures/ecosystem/poulain.jpg) [3D Digital Territory Lab](https://cesiumjs.org/demos/grandlyon/) |
-![](figures/ecosystem/cesme.jpg) [Çeşme 3D City Model](https://cesiumjs.org/demos/Cesme3DCityModel/) |
+![](figures/ecosystem/geopipe.jpg) [geopipe](https://geopi.pe/) | ![](figures/ecosystem/poulain.jpg) [3D Digital Territory Lab](https://cesium.com/blog/2018/02/05/digital-territory-lab/) |
+![](figures/ecosystem/cesme.jpg) [Çeşme 3D City Model](https://cesium.com/blog/2018/03/26/cesme-3d-city-model/) |

--- a/Q-and-A.md
+++ b/Q-and-A.md
@@ -23,15 +23,15 @@
 
 #### Is 3D Tiles specific to Cesium?
 
-No, 3D Tiles is a general spec for streaming massive heterogeneous 3D geospatial datasets.  The Cesium team started this initiative because we need an open format optimized for streaming 3D content to Cesium.  [AGI](http://www.agi.com/), the founder of Cesium, is also developing tools for creating 3D Tiles.  We expect to see other visualization engines and conversion tools use 3D Tiles.
+No, 3D Tiles is a general spec for streaming massive heterogeneous 3D geospatial datasets.  The Cesium team started this initiative because we need an open format optimized for streaming 3D content to CesiumJS.  We expect to see other visualization engines and conversion tools use 3D Tiles.
 
 #### What is the relationship between 3D Tiles and glTF?
 
-[glTF](https://www.khronos.org/gltf) is an open standard for 3D models from Khronos (the same group that does WebGL and COLLADA).  Cesium uses glTF as its 3D model format, and the Cesium team contributes heavily to the glTF spec and open-source COLLADA2GLTF converter.  We recommend using glTF in Cesium for individual assets, e.g., an aircraft, a character, or a 3D building.
+[glTF](https://www.khronos.org/gltf) is an open standard for 3D models from Khronos (the same group that does WebGL and COLLADA).  CesiumJS uses glTF as its 3D model format, and the Cesium team contributes heavily to the glTF spec and open-source COLLADA2GLTF converter.  We recommend using glTF in CesiumJS for individual assets, e.g., an aircraft, a character, or a 3D building.
 
-We created 3D Tiles for streaming massive geospatial datasets where a single glTF model would be prohibitive.  Given that glTF is optimized for rendering, that Cesium has a well-tested glTF loader, and that there are existing conversion tools for glTF, 3D Tiles use glTF for some tile formats such as [Batched 3D Model](./specification/TileFormats/Batched3DModel/README.md).
+We created 3D Tiles for streaming massive geospatial datasets where a single glTF model would be prohibitive.  Given that glTF is optimized for rendering, that CesiumJS has a well-tested glTF loader, and that there are existing conversion tools for glTF, 3D Tiles use glTF for some tile formats such as [Batched 3D Model](./specification/TileFormats/Batched3DModel/README.md).
 
-Taking this approach allows us to improve Cesium, glTF, and 3D Tiles at the same time, e.g., when we add mesh compression to glTF, it benefits 3D models in Cesium, the glTF ecosystem, and 3D Tiles.
+Taking this approach allows us to improve CesiumJS, glTF, and 3D Tiles at the same time, e.g., when we add mesh compression to glTF, it benefits 3D models in CesiumJS, the glTF ecosystem, and 3D Tiles.
 
 #### Does 3D Tiles support runtime editing?
 
@@ -41,7 +41,7 @@ The general case runtime editing of geometry on a building, vector data, etc., a
 
 #### Will 3D Tiles include terrain?
 
-Yes, a [quantized-mesh](https://github.com/AnalyticalGraphicsInc/quantized-mesh/blob/master/README.md)-like tile would fit well with 3D Tiles and allow engines to use the same streaming code (we say _quantized-mesh-like_ because some of the metadata, e.g., for bounding volumes and horizon culling, may be organized differently or moved to the tileset JSON).
+Yes, a [quantized-mesh](https://github.com/CesiumGS/quantized-mesh/blob/master/README.md)-like tile would fit well with 3D Tiles and allow engines to use the same streaming code (we say _quantized-mesh-like_ because some of the metadata, e.g., for bounding volumes and horizon culling, may be organized differently or moved to the tileset JSON).
 
 However, since quantized-mesh already streams terrain well, we are not focused on this in the short-term.
 
@@ -89,7 +89,7 @@ At runtime, a tile's `geometricError` is used to compute the screen space error 
 
 However, we do anticipate other metadata for driving refinement.  SSE may not be appropriate for all datasets; for example, points of interest may be better served with on/off distances and a label collision factor computed at runtime.  Note that the viewer's height above the ground is rarely a good metric for 3D since 3D supports arbitrary views.
 
-See [#15](https://github.com/AnalyticalGraphicsInc/3d-tiles/issues/15).
+See [#15](https://github.com/CesiumGS/3d-tiles/issues/15).
 
 #### How are cracks between tiles with vector data handled?
 
@@ -101,7 +101,7 @@ Often when using replacement refinement, a tile's children are not rendered unti
 
 We may design 3D Tiles to support downloading all children in a single request by allowing the tileset to point to a subset of a payload for a tile's content similiar to glTF [buffers and buffer views](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#buffers-and-buffer-views).  [HTTP/2](http://chimera.labs.oreilly.com/books/1230000000545/ch12.html#_brief_history_of_spdy_and_http_2) will also make the overhead of multiple requests less important.
 
-See [#9](https://github.com/AnalyticalGraphicsInc/3d-tiles/issues/9).
+See [#9](https://github.com/CesiumGS/3d-tiles/issues/9).
 
 #### How can additive refinement be optimized?
 
@@ -109,7 +109,7 @@ Compared to replacement refinement, additive refinement has a size advantage bec
 
 3D Tiles can optimize this by storing an optional spatial data structure in each tile.  For example, a tile could contain a simple 2x2 grid, and if the tile's bounding volume is not completely inside the view frustum, each box in the grid is checked against the frustum, and only those inside or intersecting are rendered.
 
-See [#11](https://github.com/AnalyticalGraphicsInc/3d-tiles/issues/11).
+See [#11](https://github.com/CesiumGS/3d-tiles/issues/11).
 
 #### What compressed texture formats does 3D Tiles use?
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Bringing techniques from the field of 3D graphics and built on [glTF](https://gi
 | Tool | Description |
 | :--- | :--- |
 | [Cesium ion](https://cesium.com/ion/) | Sign up for an account to to upload and convert content to 3D Tiles. Supports: <ul><li>glTF (.gltf, .glb)</li><li>CityGML (.citygml, .xml, .gml)</li><li>KML/COLLADA (.kml, .kmz)</li><li>LASer (.las, .laz)</li><li>COLLADA (.dae)</li><li>Wavefront OBJ (.obj)</li></ul> |
-| [CesiumJS](http://cesiumjs.org/) | Open source JavaScript runtime engine for visualizing 3D Tiles |
-| [3D Tiles Validator](https://github.com/AnalyticalGraphicsInc/3d-tiles-tools/tree/master/validator) | Open source Node.js library and command-line tools for validating 3D Tiles |
-| [3D Tiles Samples](https://github.com/AnalyticalGraphicsInc/3d-tiles-tools/tree/master/samples-generator) | Open source command-line tools for generating sample 3D Tiles  |
+| [CesiumJS](https://cesium.com/cesiumjs/) | Open source JavaScript runtime engine for visualizing 3D Tiles |
+| [3D Tiles Validator](https://github.com/CesiumGS/3d-tiles-validator/tree/master/validator) | Open source Node.js library and command-line tools for validating 3D Tiles |
+| [3D Tiles Samples](https://github.com/CesiumGS/3d-tiles-validator/tree/master/samples-generator) | Open source command-line tools for generating sample 3D Tiles  |
 | [Safe FME](https://hub.safe.com/packages/safe/cesiumion) | Desktop application for transforming data. The `CesiumIonConnector` converts data to 3D Tiles via Cesium ion. |
 | [Bentley ContextCapture](https://www.bentley.com/en/products/product-line/reality-modeling-software/contextcapture) | Desktop application for converting photographs and/or point clouds to 3D Tiles. |
 
@@ -47,9 +47,9 @@ See the [3D Tiles Ecosystem](./ECOSYSTEM.md) for examples of who's using 3D Tile
 
 ## Future Work
 
-Additional tile formats are under development, including Vector Data (`vctr`) [[#124](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/3d-tiles-next/TileFormats/VectorData)] for geospatial features such as points, lines, and polygons.
+Additional tile formats are under development, including Vector Data (`vctr`) [[#124](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/TileFormats/VectorData)] for geospatial features such as points, lines, and polygons.
 
-See the full roadmap issue for plans post version 1.0 [[#309](https://github.com/AnalyticalGraphicsInc/3d-tiles/issues/309)], as well as issues marked as **3D Tiles [Next](https://github.com/AnalyticalGraphicsInc/3d-tiles/issues?q=is%3Aissue+is%3Aopen+label%3Anext)**.
+See the full roadmap issue for plans post version 1.0 [[#309](https://github.com/CesiumGS/3d-tiles/issues/309)], as well as issues marked as **3D Tiles [Next](https://github.com/CesiumGS/3d-tiles/issues?q=is%3Aissue+is%3Aopen+label%3Anext)**.
 
 ## Contributing
 
@@ -57,6 +57,6 @@ See the full roadmap issue for plans post version 1.0 [[#309](https://github.com
 
 ---
 
-Created by the <a href="http://cesiumjs.org/">Cesium team</a> and built on <a href="https://www.khronos.org/gltf">glTF</a>.<br/>
+Created by the <a href="https://cesium.com/">Cesium team</a> and built on <a href="https://www.khronos.org/gltf">glTF</a>.<br/>
 
-<a href="http://cesiumjs.org/"><img src="figures/cesium.jpg" height="40" /></a> <a href="https://www.khronos.org/gltf"><img src="figures/gltf.png" height="40" /></a>
+<a href="https://cesium.com/"><img src="figures/cesium.jpg" height="40" /></a> <a href="https://www.khronos.org/gltf"><img src="figures/gltf.png" height="40" /></a>

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -7,7 +7,7 @@
 **Selected Talks**
    * _3D Tiles in Action_ ([pdf](https://cesium.com/presentations/files/3DTilesInAction.pdf)) at FOSS4G 2017.
    * _Point Clouds with 3D Tiles_ ([pdf](https://cesium.com/presentations/files/PointCloudsWith3DTiles.pdf)) at the OGC Technical Committee Meeting (June 2017).
-   * _The Open Cesium 3D Tiles Specification: Bringing Massive Geospatial 3D Scenes to the Web_ ([pptx](https://cesium.com/presentations/files/Web3D-2016-3DTilesTutorial.pptx), [example tilesets](https://github.com/AnalyticalGraphicsInc/3d-tiles-samples)) at Web3D 2016.  90-minute technical tutorial.
+   * _The Open Cesium 3D Tiles Specification: Bringing Massive Geospatial 3D Scenes to the Web_ ([pptx](https://cesium.com/presentations/files/Web3D-2016-3DTilesTutorial.pptx), [example tilesets](https://github.com/CesiumGS/3d-tiles-samples)) at Web3D 2016.  90-minute technical tutorial.
    * _3D Tiles: Beyond 2D Tiling_ ([pdf](https://cesium.com/presentations/files/FOSS4GNA2016/3DTiles.pdf), [video](https://www.youtube.com/watch?v=I1vYCrMKKEE)) at FOSS4G NA 2016.
    * _3D Tiles motivation and ecosystem update_ ([pdf](https://cesium.com/presentations/files/3D-Tiles-OGC-DC.pdf)) at the OGC Technical Committee Meeting (March 2016).
    * _3D Tiles intro_ ([pdf](https://cesium.com/presentations/files/SIGGRAPH2015/Cesium3DTiles.pdf)) at the Cesium BOF at SIGGRAPH 2015.

--- a/extensions/3DTILES_draco_point_compression/README.md
+++ b/extensions/3DTILES_draco_point_compression/README.md
@@ -142,7 +142,7 @@ case `POINT_CLOUD_SEQUENTIAL_ENCODING` should not be applied.
 _This section is non-normative._
 
 * [Draco Open Source Library](https://github.com/google/draco)
-* [Cesium Draco Decoder Implementation](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Workers/decodeDraco.js)
+* [Cesium Draco Decoder Implementation](https://github.com/CesiumGS/cesium/blob/master/Source/Workers/decodeDraco.js)
 
 ## Property reference
 

--- a/specification/README.md
+++ b/specification/README.md
@@ -8,9 +8,9 @@ This document describes the specification for 3D Tiles, an open standard for str
 
 
 Editors:
-  * Patrick Cozzi, [@pjcozzi](https://twitter.com/pjcozzi), [pcozzi@agi.com](mailto:pcozzi@agi.com)
-  * Sean Lilley, [@lilleyse](https://twitter.com/lilleyse), [slilley@agi.com](mailto:slilley@agi.com)
-  * Gabby Getz, [@gabbygetz](https://twitter.com/gabbygetz), [ggetz@agi.com](mailto:ggetz@agi.com)
+  * Patrick Cozzi, [@pjcozzi](https://twitter.com/pjcozzi), [patrick@cesium.com](mailto:patrick@cesium.com)
+  * Sean Lilley, [@lilleyse](https://twitter.com/lilleyse), [sean@cesium.com](mailto:sean@cesium.com)
+  * Gabby Getz, [@gabbygetz](https://twitter.com/gabbygetz), [gabby@cesium.com](mailto:gabby@cesium.com)
 
 Acknowledgements:
 * Matt Amato, [@matt_amato](https://twitter.com/matt_amato)
@@ -291,7 +291,7 @@ The following example has a building in a `b3dm` tile and a point cloud inside t
 }
 ```
 
-For more on request volumes, see the [sample tileset](https://github.com/AnalyticalGraphicsInc/3d-tiles-samples/tree/master/tilesets/TilesetWithRequestVolume) and [demo video](https://www.youtube.com/watch?v=PgX756Yzjf4).
+For more on request volumes, see the [sample tileset](https://github.com/CesiumGS/3d-tiles-samples/tree/master/tilesets/TilesetWithRequestVolume) and [demo video](https://www.youtube.com/watch?v=PgX756Yzjf4).
 
 #### Transforms
 
@@ -395,7 +395,7 @@ Therefore, the full computed transforms for the above example are:
 
 _This section is non-normative_
 
-The following JavaScript code shows how to compute this using Cesium's [Matrix4](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Core/Matrix4.js) and [Matrix3](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Core/Matrix3.js) types.
+The following JavaScript code shows how to compute this using Cesium's [Matrix4](https://github.com/CesiumGS/cesium/blob/master/Source/Core/Matrix4.js) and [Matrix3](https://github.com/CesiumGS/cesium/blob/master/Source/Core/Matrix3.js) types.
 
 ```javascript
 function computeTransforms(tileset) {
@@ -477,7 +477,7 @@ A file extension is not required for `content.uri`.  A content's [tile format](#
 
 The `content.boundingVolume` property defines an optional [bounding volume](#bounding-volumes) similar to the top-level `boundingVolume` property. But unlike the top-level `boundingVolume` property, `content.boundingVolume` is a tightly fit bounding volume enclosing just the tile's content.  `boundingVolume` provides spatial coherence and `content.boundingVolume` enables tight view frustum culling, excluding from rendering any content not in the volume of what is potentially in view.  When it is not defined, the tile's bounding volume is still used for culling (see [Grids](#grids)).
 
-The screenshot below shows the bounding volumes for the root tile for [Canary Wharf](http://cesiumjs.org/CanaryWharf/).  `boundingVolume`, shown in red, encloses the entire area of the tileset; `content.boundingVolume` shown in blue, encloses just the four features (models) in the root tile.
+The screenshot below shows the bounding volumes for the root tile for Canary Wharf.  `boundingVolume`, shown in red, encloses the entire area of the tileset; `content.boundingVolume` shown in blue, encloses just the four features (models) in the root tile.
 
 ![](figures/contentsBox.png)
 
@@ -491,7 +491,7 @@ See [Property reference](#property-reference) for the tile JSON schema reference
 
 3D Tiles uses one main tileset JSON file as the entry point to define a tileset. Both entry and external tileset JSON files are not required to follow a specific naming convention.
 
-Here is a subset of the tileset JSON used for [Canary Wharf](http://cesiumjs.org/CanaryWharf/) (also see the complete file, [`tileset.json`](../examples/tileset.json)):
+Here is a subset of the tileset JSON used for Canary Wharf (also see the complete file, [`tileset.json`](../examples/tileset.json)):
 ```json
 {
   "asset" : {
@@ -1177,7 +1177,7 @@ Application-specific data.
 
 ## License
 
-Copyright 2016 - 2018 Cesium
+Copyright 2016 - 2020 Cesium GS, Inc.
 
 This Specification is licensed under a [Creative Commons Attribution 4.0 International License (CC BY 4.0)](http://creativecommons.org/licenses/by/4.0/).
 

--- a/specification/Styling/README.md
+++ b/specification/Styling/README.md
@@ -203,7 +203,7 @@ A meta property expression can evaluate to any type. For example:
 
 The language for expressions is a small subset of JavaScript ([EMCAScript 5](http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf)), plus native vector and regular expression types and access to tileset feature properties in the form of readonly variables.
 
-> **Implementation Note:** Cesium uses the [jsep](http://jsep.from.so/) JavaScript expression parser library to parse style expressions into an [abstract syntax tree (AST)](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
+> **Implementation Note:** CesiumJS uses the [jsep](http://jsep.from.so/) JavaScript expression parser library to parse style expressions into an [abstract syntax tree (AST)](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
 
 ### Semantics
 

--- a/specification/TileFormats/BatchTable/README.md
+++ b/specification/TileFormats/BatchTable/README.md
@@ -163,7 +163,7 @@ var geographicArray = new Float64Array(batchTableBinary.buffer, byteOffset, geog
 var geographicOfFeature = positionArray.subarray(batchId * numberOfComponents, batchId * numberOfComponents + numberOfComponents); // Using subarray creates a view into the array, and not a new array.
 ```
 
-Code for reading the Batch Table can be found in [`Cesium3DTileBatchTable.js`](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/Cesium3DTileBatchTable.js) in the Cesium implementation of 3D Tiles.
+Code for reading the Batch Table can be found in [`Cesium3DTileBatchTable.js`](https://github.com/CesiumGS/cesium/blob/master/Source/Scene/Cesium3DTileBatchTable.js) in the CesiumJS implementation of 3D Tiles.
 
 ## Property reference
 

--- a/specification/TileFormats/Batched3DModel/README.md
+++ b/specification/TileFormats/Batched3DModel/README.md
@@ -151,8 +151,8 @@ An explicit file extension is optional. Valid implementations may ignore it and 
 _This section is non-normative_
 
 Code for reading the header can be found in
-[`Batched3DModelTileContent.js`](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/Batched3DModel3DTileContent.js)
-in the Cesium implementation of 3D Tiles.
+[`Batched3DModelTileContent.js`](https://github.com/CesiumGS/cesium/blob/master/Source/Scene/Batched3DModel3DTileContent.js)
+in the CesiumJS implementation of 3D Tiles.
 
 
 ### Property reference

--- a/specification/TileFormats/Composite/README.md
+++ b/specification/TileFormats/Composite/README.md
@@ -69,5 +69,5 @@ _This section is non-normative_
 
 * [Python `packcmpt` tool in gltf2glb toolset](https://github.com/Geopipe/gltf2glb) contains code for combining one or more _Batched 3D Model_ or _Instanced 3D Model_ tiles into a single Composite tile file.
 * Code for reading the header can be found in
-[`Composite3DTileContent.js`](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/Composite3DTileContent.js)
-in the Cesium implementation of 3D Tiles.
+[`Composite3DTileContent.js`](https://github.com/CesiumGS/cesium/blob/master/Source/Scene/Composite3DTileContent.js)
+in the CesiumJS implementation of 3D Tiles.

--- a/specification/TileFormats/FeatureTable/README.md
+++ b/specification/TileFormats/FeatureTable/README.md
@@ -71,7 +71,7 @@ var positionArray = new Float32Array(featureTableBinary.buffer, byteOffset, feat
 var position = positionArray.subarray(featureId * 3, featureId * 3 + 3); // Using subarray creates a view into the array, and not a new array.
 ```
 
-Code for reading the Feature Table can be found in [`Cesium3DTileFeatureTable.js`](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/Cesium3DTileFeatureTable.js) in the Cesium implementation of 3D Tiles.
+Code for reading the Feature Table can be found in [`Cesium3DTileFeatureTable.js`](https://github.com/CesiumGS/cesium/blob/master/Source/Scene/Cesium3DTileFeatureTable.js) in the CesiumJS implementation of 3D Tiles.
 
 
 ## Property reference

--- a/specification/TileFormats/Instanced3DModel/README.md
+++ b/specification/TileFormats/Instanced3DModel/README.md
@@ -24,8 +24,6 @@
 * [glTF](#gltf)
     * [Coordinate system](#coordinate-system)
 * [File extension and MIME type](#file-extension-and-mime-type)
-* [Implementation example](#implementation-example)
-    * [Cesium](#cesium)
 * [Property reference](#property-reference)
 
 ## Overview
@@ -134,7 +132,7 @@ A box transformed into a rotated basis
 If `NORMAL_UP` and `NORMAL_RIGHT` are not defined for an instance, its orientation may be stored as oct-encoded normals in `NORMAL_UP_OCT32P` and `NORMAL_RIGHT_OCT32P`.
 These define `up` and `right` using the oct-encoding described in [*A Survey of Efficient Representations of Independent Unit Vectors*](http://jcgt.org/published/0003/02/01/). Oct-encoded values are stored in unsigned, unnormalized range (`[0, 65535]`) and then mapped to a signed normalized range (`[-1.0, 1.0]`) at runtime.
 
-> An implementation for encoding and decoding these unit vectors can be found in Cesium's [AttributeCompression](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Core/AttributeCompression.js)
+> An implementation for encoding and decoding these unit vectors can be found in CesiumJS's [AttributeCompression](https://github.com/CesiumGS/cesium/blob/master/Source/Core/AttributeCompression.js)
 module.
 
 #### Default orientation

--- a/specification/TileFormats/PointCloud/README.md
+++ b/specification/TileFormats/PointCloud/README.md
@@ -153,7 +153,7 @@ The normals will be transformed using the inverse transpose of the tileset trans
 
 Oct-encoding is described in [*A Survey of Efficient Representations of Independent Unit Vectors*](http://jcgt.org/published/0003/02/01/). Oct-encoded values are stored in unsigned, unnormalized range (`[0, 255]`) and then mapped to a signed normalized range (`[-1.0, 1.0]`) at runtime.
 
-> An implementation for encoding and decoding these unit vectors can be found in Cesium's [AttributeCompression](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Core/AttributeCompression.js)
+> An implementation for encoding and decoding these unit vectors can be found in CesiumJS's [AttributeCompression](https://github.com/CesiumGS/cesium/blob/master/Source/Core/AttributeCompression.js)
 module.
 
 ### Batched points
@@ -343,7 +343,7 @@ An explicit file extension is optional. Valid implementations may ignore it and 
 
 _This section is non-normative_
 
-Code for reading the header can be found in [`PointCloud3DModelTileContent.js`](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/PointCloud3DTileContent.js) in the Cesium implementation of 3D Tiles.
+Code for reading the header can be found in [`PointCloud3DModelTileContent.js`](https://github.com/CesiumGS/cesium/blob/master/Source/Scene/PointCloud3DTileContent.js) in the CesiumJS implementation of 3D Tiles.
 
 ## Property reference
 

--- a/specification/schema/README.md
+++ b/specification/schema/README.md
@@ -6,7 +6,7 @@ Parts of 3D Tiles, such as [Tileset JSON](../README.md#tileset-json), [Feature T
 
 A JSON object can be validated against the schema using a JSON schema validator such as [Ajv: Another JSON Schema Validator](https://github.com/epoberezkin/ajv), which supports JSON Schema draft v4.  A command-line tool is available on npm as [ajv-cli](https://www.npmjs.com/package/ajv-cli).
 
-Validating against the schema does not prove full compliance with the 3D Tiles specification since not all requirements can be represented with JSON schema.  For full compliance validation, see [3d-tiles-tools](https://github.com/AnalyticalGraphicsInc/3d-tiles-tools/).
+Validating against the schema does not prove full compliance with the 3D Tiles specification since not all requirements can be represented with JSON schema.  For full compliance validation, see [3d-tiles-validator](https://github.com/CesiumGS/3d-tiles-validator/).
 
 ### Example
 


### PR DESCRIPTION
Part of the CesiumGS github migration.
See https://groups.google.com/forum/?hl=en#!topic/cesium-dev/5sFSChDEtCg