### PR TITLE
Adds 3DTILES_binary_buffers extension

### DIFF
--- a/extensions/3DTILES_binary_buffers/README.md
+++ b/extensions/3DTILES_binary_buffers/README.md
@@ -41,3 +41,100 @@ Buffers are binary blobs of data.
 ### Buffer Views
 
 Buffer views offer typed views into buffers. They specify a subset of the data stored in a buffer through a `byteOffset` and a `byteLength`. The type of data inside the buffers can be derived from the `elementType` and the `componentType` properties.
+
+## Examples
+
+### 3DTILES_implicit_tiling and 3DTILES_tile_metadata
+
+```json
+{
+    "asset": {
+        "version": "2.0.0-alpha.0"
+    },
+    "extensions": {
+        "3DTILES_implicit_tiling": {
+            "tilingScheme": "quadtree",
+            "subdivision": {
+                "completeLevels": 2,
+                "bufferView": 0
+            },
+            "content": {
+                "levelOffset": 2,
+                "levelOffsetFill": 0,
+                "bufferView": 1
+            },
+            "metadata": {
+                "levelOffset": 2,
+                "levelOffsetFill": 0,
+                "bufferView": 1
+            }
+        },
+        "3DTILES_tile_metadata": {
+            "properties": {
+                "surfaceArea": {
+                    "semantic": "_SURFACE_AREA",
+                    "bufferView": 2
+                },
+                "tileId": {
+                    "semantic": "_TILE_ID",
+                    "bufferView": 3
+                }
+            }
+        },
+        "3DTILES_binary_buffers": {
+            "bufferViews": [
+                {
+                    "elementType": "VEC2",
+                    "componentType": "BIT",
+                    "byteOffset": 0,
+                    "byteLength": 2,
+                    "buffer": 0
+                },
+                {
+                    "elementType": "SCALAR",
+                    "componentType": "BIT",
+                    "byteOffset": 2,
+                    "byteLength": 4,
+                    "buffer": 0
+                },
+                {
+                    "elementType": "SCALAR",
+                    "componentType": "FLOAT",
+                    "byteOffset": 0,
+                    "byteLength": 32,
+                    "buffer": 1
+                },
+                {
+                    "elementType": "STRING",
+                    "byteOffset": 32,
+                    "byteLength": 64,
+                    "elementsOffsetBufferView": 5,
+                    "buffer": 2
+                },
+                {
+                    "elementType": "SCALAR",
+                    "componentType": "UNSIGNED_INT",
+                    "byteOffset": 0,
+                    "byteLength": 32,
+                    "buffer": 2
+                }
+            ],
+            "buffer": [
+                {
+                    "uri": "implicit.bin",
+                    "byteLength": 6
+                },
+                {
+                    "uri": "metadata_surface_area.bin",
+                    "byteLength": 32
+                },
+                {
+                    "uri": "metadata_tile_id.bin",
+                    "byteLength": 96
+                }
+            ]
+        }
+    }
+}
+
+```

--- a/extensions/3DTILES_binary_buffers/README.md
+++ b/extensions/3DTILES_binary_buffers/README.md
@@ -1,0 +1,43 @@
+# 3DTILES_binary_buffers
+
+## Overview
+
+This extension to 3D Tiles enables storage of binary data in external buffers.
+
+## Concepts
+
+### Element Types
+
+| Element Type | No. of components |
+|:------------:|:-----------------:|
+| SCALAR | 1 |
+| STRING | 1 |
+| VEC2 | 2 |
+| VEC3 | 3 | 
+| VEC4 | 4 |
+| MAT2 | 4 |
+| MAT3 | 9 |
+| MAT4 | 16 |
+
+### Component Types
+
+| Component | Size (bits) |
+|:---------:|:------------:|
+| BIT | 1 |
+| BYTE | 8 |
+| UNSIGNED_BYTE | 8 |
+| SHORT | 16 |
+| UNSIGNED_SHORT | 16 |
+| HALF_FLOAT | 16 |
+| INT | 32 |
+| UNSIGNED_INT | 32 |
+| FLOAT | 32 |
+| DOUBLE | 64 |
+
+### Buffers
+
+Buffers are binary blobs of data.
+
+### Buffer Views
+
+Buffer views offer typed views into buffers. They specify a subset of the data stored in a buffer through a `byteOffset` and a `byteLength`. The type of data inside the buffers can be derived from the `elementType` and the `componentType` properties.

--- a/extensions/3DTILES_binary_buffers/README.md
+++ b/extensions/3DTILES_binary_buffers/README.md
@@ -4,6 +4,35 @@
 
 This extension to 3D Tiles enables storage of binary data in external buffers.
 
+## Data Alignment
+
+The byte offset of a buffer view into a buffer must be a multiple of the size of the buffer view's component type. For a buffer view that uses the `BIT` element type, the data must be padded with `0`s to meet the nearest byte boundary.
+
+Buffer views of matrix type have data stored in column-major order; start of each column must be aligned to 4-byte boundaries. To achieve this, three `elementType`/`componentType` combinations require special layout:
+
+**MAT2, 1-byte components**
+```
+| 00| 01| 02| 03| 04| 05| 06| 07| 
+|===|===|===|===|===|===|===|===|
+|m00|m10|---|---|m01|m11|---|---|
+```
+
+**MAT3, 1-byte components**
+```
+| 00| 01| 02| 03| 04| 05| 06| 07| 08| 09| 0A| 0B|
+|===|===|===|===|===|===|===|===|===|===|===|===|
+|m00|m10|m20|---|m01|m11|m21|---|m02|m12|m22|---|
+```
+
+**MAT3, 2-byte components**
+```
+| 00| 01| 02| 03| 04| 05| 06| 07| 08| 09| 0A| 0B| 0C| 0D| 0E| 0F| 10| 11| 12| 13| 14| 15| 16| 17|
+|===|===|===|===|===|===|===|===|===|===|===|===|===|===|===|===|===|===|===|===|===|===|===|===|
+|m00|m00|m10|m10|m20|m20|---|---|m01|m01|m11|m11|m21|m21|---|---|m02|m02|m12|m12|m22|m22|---|---|
+```
+
+Alignment requirements apply only to start of each column, so trailing bytes could be omitted if there's no further data. 
+
 ## Properties Reference
 
 ---------------------------------------
@@ -19,9 +48,9 @@ This extension to 3D Tiles enables storage of binary data in external buffers.
 |**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|☑️ Yes|
 |**byteLength**|`integer`|The length of the bufferView in bytes.| ☑️ Yes|
 |**elementCount**|`integer`|The number of elements in the buffer view.| ☑️ Yes|
-|**elementByteOffsetsBufferView**|`integer`|The index of the bufferView containing byte offsets for each element. Must be defined for the STRING element type.|No|
+|**elementByteOffsetsBufferView**|`integer`|The index of the bufferView containing byte offsets for each element. Must be defined for the STRING and NONUNIFORM element types.|No|
 |**elementType**|`string`|Specifies if the attribute is a scalar, vector, matrix or string.|No, default is `SCALAR`.|
-|**componentType**|`string`|The datatype of components in the attribute. Must be defined for every other element type, except STRING (in which case it will be ignored).|No|
+|**componentType**|`string`|The datatype of components in the attribute. Must be defined for every other element type, except STRING and NONUNIFORM (in which case it will be ignored).|No|
 
 
 #### Element Types
@@ -30,6 +59,7 @@ This extension to 3D Tiles enables storage of binary data in external buffers.
 |:------------:|:-----------------:|
 | SCALAR | 1 |
 | STRING | 1 |
+| NONUNIFORM | 1 |
 | VEC2 | 2 |
 | VEC3 | 3 | 
 | VEC4 | 4 |
@@ -54,8 +84,6 @@ This extension to 3D Tiles enables storage of binary data in external buffers.
 | FLOAT | 32 |
 | DOUBLE | 64 |
 
-
-*Note: The buffer views for the `BIT` component type must be padded with trailing `0`s to meet the nearest byte boundary.*
 
 ---------------------------------------
 ### 3DTILES_binary_buffers.buffers

--- a/extensions/3DTILES_binary_buffers/README.md
+++ b/extensions/3DTILES_binary_buffers/README.md
@@ -4,9 +4,27 @@
 
 This extension to 3D Tiles enables storage of binary data in external buffers.
 
-## Concepts
+## Properties Reference
 
-### Element Types
+---------------------------------------
+### 3DTILES_binary_buffers.bufferViews
+
+`bufferViews` provide a typed view into a `buffer`.
+
+**Properties**
+
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**buffer**|`integer`|The index of the buffer.|☑️ Yes|
+|**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|☑️ Yes|
+|**byteLength**|`integer`|The length of the bufferView in bytes.| ☑️ Yes|
+|**elementCount**|`integer`|The number of elements in the buffer view.| ☑️ Yes|
+|**elementByteOffsetsBufferView**|`integer`|The index of the bufferView containing byte offsets for each element. Must be defined for the STRING type.|No|
+|**elementType**|`string`|Specifies if the attribute is a scalar, vector, matrix or string.|No, default is `SCALAR`.|
+|**componentType**|`string`|The datatype of components in the attribute.|☑️ Yes|
+
+
+#### Element Types
 
 | Element Type | No. of components |
 |:------------:|:-----------------:|
@@ -19,7 +37,9 @@ This extension to 3D Tiles enables storage of binary data in external buffers.
 | MAT3 | 9 |
 | MAT4 | 16 |
 
-### Component Types
+*Note: The `STRING` element type only stores UTF-8 encoded strings.*
+
+#### Component Types
 
 | Component | Size (bits) |
 |:---------:|:------------:|
@@ -34,13 +54,17 @@ This extension to 3D Tiles enables storage of binary data in external buffers.
 | FLOAT | 32 |
 | DOUBLE | 64 |
 
-### Buffers
 
-Buffers are binary blobs of data.
+---------------------------------------
+### 3DTILES_binary_buffers.buffers
+A buffer points to a blob data.
 
-### Buffer Views
+**Properties**
 
-Buffer views offer typed views into buffers. They specify a subset of the data stored in a buffer through a `byteOffset` and a `byteLength`. The type of data inside the buffers can be derived from the `elementType` and the `componentType` properties.
+|   |Type|Description|Required|
+|---|----|-----------|--------|
+|**uri**|`string`|The uri of the buffer.| ☑️ Yes|
+|**byteLength**|`integer`|The total byte length of the buffer view.| ☑️ Yes|
 
 ## Examples
 
@@ -108,7 +132,7 @@ Buffer views offer typed views into buffers. They specify a subset of the data s
                     "elementType": "STRING",
                     "byteOffset": 32,
                     "byteLength": 64,
-                    "elementsOffsetBufferView": 5,
+                    "elementByteOffsetsBufferView": 5,
                     "buffer": 2
                 },
                 {

--- a/extensions/3DTILES_binary_buffers/README.md
+++ b/extensions/3DTILES_binary_buffers/README.md
@@ -55,6 +55,8 @@ This extension to 3D Tiles enables storage of binary data in external buffers.
 | DOUBLE | 64 |
 
 
+*Note: The buffer views for the `BIT` component type must be padded with trailing `0`s to meet the nearest byte boundary.*
+
 ---------------------------------------
 ### 3DTILES_binary_buffers.buffers
 A buffer points to a blob data.

--- a/extensions/3DTILES_binary_buffers/README.md
+++ b/extensions/3DTILES_binary_buffers/README.md
@@ -21,7 +21,7 @@ This extension to 3D Tiles enables storage of binary data in external buffers.
 |**elementCount**|`integer`|The number of elements in the buffer view.| ☑️ Yes|
 |**elementByteOffsetsBufferView**|`integer`|The index of the bufferView containing byte offsets for each element. Must be defined for the STRING element type.|No|
 |**elementType**|`string`|Specifies if the attribute is a scalar, vector, matrix or string.|No, default is `SCALAR`.|
-|**componentType**|`string`|The datatype of components in the attribute. Cannot be defined for the STRING element type.|No|
+|**componentType**|`string`|The datatype of components in the attribute. Must be defined for every other element type, except STRING (in which case it will be ignored).|No|
 
 
 #### Element Types
@@ -64,7 +64,7 @@ A buffer points to a blob data.
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**uri**|`string`|The uri of the buffer.| ☑️ Yes|
-|**byteLength**|`integer`|The total byte length of the buffer view.| ☑️ Yes|
+|**byteLength**|`integer`|The total byte length of the buffer.| ☑️ Yes|
 
 ## Examples
 
@@ -73,7 +73,7 @@ A buffer points to a blob data.
 ```json
 {
     "asset": {
-        "version": "2.0.0-alpha.0"
+        "version": "1.0"
     },
     "extensions": {
         "3DTILES_implicit_tiling": {
@@ -132,7 +132,7 @@ A buffer points to a blob data.
                     "elementType": "STRING",
                     "byteOffset": 32,
                     "byteLength": 64,
-                    "elementByteOffsetsBufferView": 5,
+                    "elementByteOffsetsBufferView": 4,
                     "buffer": 2
                 },
                 {
@@ -143,7 +143,7 @@ A buffer points to a blob data.
                     "buffer": 2
                 }
             ],
-            "buffer": [
+            "buffers": [
                 {
                     "uri": "implicit.bin",
                     "byteLength": 6

--- a/extensions/3DTILES_binary_buffers/README.md
+++ b/extensions/3DTILES_binary_buffers/README.md
@@ -19,9 +19,9 @@ This extension to 3D Tiles enables storage of binary data in external buffers.
 |**byteOffset**|`integer`|The offset relative to the start of the buffer in bytes.|☑️ Yes|
 |**byteLength**|`integer`|The length of the bufferView in bytes.| ☑️ Yes|
 |**elementCount**|`integer`|The number of elements in the buffer view.| ☑️ Yes|
-|**elementByteOffsetsBufferView**|`integer`|The index of the bufferView containing byte offsets for each element. Must be defined for the STRING type.|No|
+|**elementByteOffsetsBufferView**|`integer`|The index of the bufferView containing byte offsets for each element. Must be defined for the STRING element type.|No|
 |**elementType**|`string`|Specifies if the attribute is a scalar, vector, matrix or string.|No, default is `SCALAR`.|
-|**componentType**|`string`|The datatype of components in the attribute.|☑️ Yes|
+|**componentType**|`string`|The datatype of components in the attribute. Cannot be defined for the STRING element type.|No|
 
 
 #### Element Types


### PR DESCRIPTION
This extension enables storage of binary buffers. Specification is available [here](https://github.com/CesiumGS/3d-tiles/blob/3DTILES_binary_buffers/extensions/3DTILES_binary_buffers/README.md).