### PR TITLE
added comment to vector data encoding example code

### DIFF
--- a/TileFormats/VectorData/README.md
+++ b/TileFormats/VectorData/README.md
@@ -123,6 +123,7 @@ The positions are represented by u, v, and height values that are quantized and 
 
 The values are then delta and ZigZag encoded. The delta encoding ensures the values are small integers. The ZigZag encoding ensures the values are positive integers. Example encoding code is listed below:
 ```javascript
+// `value` must be an integer. Otherwise, the decoded value won't neccessarily equal the encoded one.
 function zigZag(value) {
     return ((value << 1) ^ (value >> 15)) & 0xFFFF;
 }


### PR DESCRIPTION
I don't know if this spec is still "alive", but I ran into a problem when writing code to create vector 3dtiles and thought that adding a hint to the spec might prevent people running into the same issue in the future.