### PR TITLE
Adds 3DTILES_binary_buffers extension

### DIFF
--- a/extensions/3DTILES_binary_buffers/README.md
+++ b/extensions/3DTILES_binary_buffers/README.md
@@ -1,0 +1,96 @@
+# 3DTILES_binary_buffers
+
+## Contributors
+
+* Sam Suhag, Cesium
+* Sean Lilley, Cesium
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the 3D Tiles 1.0 spec.
+
+## Contents
+
+  - [Overview](#overview)
+  - [Optional vs. Required](#optional-vs-required)
+  - [Schema Updates](#schema-updates)
+  - [Examples](#examples)
+
+## Overview
+
+This extension enables storage of binary data in external buffers.
+
+## Optional vs. Required
+
+This extension is required if extensions that depend on it are required. Otherwise it is optional. If required it should be placed in the tileset JSON top-level `extensionsRequired` list.
+
+## Schema Updates
+
+`3DTILES_binary_buffers` is a property of the top-level `extensions` object and contains two properties:
+
+* `bufferViews`: an array of buffer views, generally representing subsets of buffers
+* `buffers`: an array of buffers pointing to binary data
+
+The full JSON schema can be found in [tileset.3DTILES_binary_buffers.schema.json](schema/tileset.3DTILES_binary_buffers.schema.json).
+
+## Examples
+
+```json
+{
+  "asset": {
+    "version": "1.0"
+  },
+  "extensionsUsed": ["3DTILES_binary_buffers"],
+  "extensionsRequired": ["3DTILES_binary_buffers"],
+  "extensions": {
+    "3DTILES_binary_buffers": {
+      "bufferViews": [
+        {
+          "buffer": 0,
+          "byteOffset": 0,
+          "byteLength": 98
+        },
+        {
+          "buffer": 0,
+          "byteOffset": 100,
+          "byteLength": 250
+        }
+      ],
+      "buffers": [
+        {
+          "uri": "external.bin",
+          "byteLength": 350
+        }
+      ],
+      "extras": {
+        "draftVersion": "0.0.0"
+      }
+    }
+  },
+  "geometricError": 240,
+  "root": {
+    "boundingVolume": {
+      "region": [-1.31972, 0.69884, -1.31964, 0.6989, 0, 88]
+    },
+    "geometricError": 70,
+    "refine": "ADD",
+    "content": {
+      "uri": "tile.b3dm",
+      "extras": {
+        "editHistory": {
+          "year": "2020",
+          "bufferView": 0
+        },
+        "author": {
+          "name": "Cesium",
+          "bufferView": 1
+        }
+      }
+    }
+  }
+}
+```

--- a/extensions/3DTILES_binary_buffers/schema/buffer.schema.json
+++ b/extensions/3DTILES_binary_buffers/schema/buffer.schema.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Buffer",
+    "type": "object",
+    "description": "A buffer that points to a uri containing binary data.",
+    "properties" : {
+        "uri": {
+            "type": "string",
+            "description": "The uri of the buffer. Relative paths are relative to the tileset. Instead of referencing an external file, the uri can also be a data-uri.",
+            "format": "uriref"
+        },
+        "byteLength": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The length of the buffer in bytes."
+        },
+        "name": {
+            "type": "string",
+            "minLength" : 1,
+            "description": "The name of the buffer. The string is UTF-8 encoded."
+        },
+        "extensions": {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
+        }
+    },
+    "required": [ "uri", "byteLength" ]
+}

--- a/extensions/3DTILES_binary_buffers/schema/bufferView.schema.json
+++ b/extensions/3DTILES_binary_buffers/schema/bufferView.schema.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Buffer View",
+    "type": "object",
+    "description": "A view into a buffer generally representing a subset of the buffer.",
+    "properties" : {
+        "buffer": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The index of the buffer."
+        },
+        "byteOffset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The offset into the buffer in bytes."
+        },
+        "byteLength": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The total byte length of the buffer view."
+        },
+        "name": {
+            "type": "string",
+            "minLength" : 1,
+            "description": "The name of the `bufferView`. The string is UTF-8 encoded."
+        },
+        "extensions": {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
+        }
+    },
+    "required": [ "buffer", "byteOffset", "byteLength" ]
+}

--- a/extensions/3DTILES_binary_buffers/schema/tileset.3DTILES_binary_buffers.schema.json
+++ b/extensions/3DTILES_binary_buffers/schema/tileset.3DTILES_binary_buffers.schema.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "3DTILES_binary_buffers extension",
+    "type": "object",
+    "description": "3D Tiles extension that enables storage of binary data in external buffers.",
+    "properties" : {
+        "bufferViews": {
+            "type": "array",
+            "description": "An array of buffer views.",
+            "items": {
+                "$ref": "bufferView.schema.json"
+            },
+            "minItems": 1
+        },
+        "buffers": {
+            "type": "array",
+            "description": "An array of buffers.",
+            "items": {
+                "$ref": "buffer.schema.json"
+            },
+            "minItems": 1
+        },
+        "extensions": {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
+        }
+    },
+    "required": [ "bufferViews", "buffers" ]
+}


### PR DESCRIPTION
Supersedes https://github.com/CesiumGS/3d-tiles/pull/415 which was not versioned.

Direct Link|Draft Version|Changes
--|--|--
[`3DTILES_binary_buffers`](https://github.com/CesiumGS/3d-tiles/blob/3DTILES_binary_buffers/extensions/3DTILES_binary_buffers) | 0.0.0 | Initial draft

This extension enables 3D Tiles to reference binary buffers. Useful as a building block for other extensions.