### PR TITLE
Adds 3DTILES_feature_metadata extension

### DIFF
--- a/extensions/3DTILES_feature_metadata/README.md
+++ b/extensions/3DTILES_feature_metadata/README.md
@@ -1,0 +1,51 @@
+# 3DTILES_feature_metadata
+
+## Contributors
+
+* Sean Lilley, Cesium
+* Samuel Vargas, Cesium
+* Sam Suhag, Cesium
+* Patrick Cozzi, Cesium
+
+## Status
+
+Draft
+
+## Dependencies
+
+Written against the 3D Tiles 1.0 spec.
+
+## Contents
+
+  - [Overview](#overview)
+  - [Optional vs. Required](#optional-vs-required)
+  - [Schema Updates](#schema-updates)
+  - [Examples](#examples)
+
+## Overview
+
+The top-level `3DTILES_feature_metadata` extension lists feature types that are referenced by tiles in the tileset. A client may use this information to populate a UI, filter metadata requests, or generate styles on-the-fly.
+
+The actual list of feature types is up to the tileset author's discretion. The list may include a select few feature types, all feature types present in this tileset (or in external tilesets), or none at all.
+
+Feature metadata may be embedded directly in glTF using the [`EXT_feature_metadata`](https://github.com/CesiumGS/glTF/tree/feature-metadata/extensions/2.0/Vendor/EXT_feature_metadata) glTF extension, or alongside the glTF (or non-glTF tile content) as a separate JSON file.
+
+When feature types are not present in the content's feature metadata, any references to feature types refer to the top-level feature types in `3DTILES_feature_metadata`.
+
+## Optional vs. Required
+
+This extension is optional, meaning it should be placed in the tileset JSON top-level `extensionsUsed` list, but not in the `extensionsRequired` list.
+
+## Schema Updates
+
+`3DTILES_feature_metadata` is a property of the top-level `extensions` object and contains one property:
+
+* `featureTypes`: an array of feature types referenced by tiles in the tileset.
+
+Feature metadata may be stored alongside tile content rather than embedded in tile content. A tile's `content` object may be extended with a `3DTILES_feature_metadata` object that points to an external file. The schema for the external file is defined in [external.featureMetadata.schema.json](schema/external.featureMetadata.schema.json) and mirrors glTF [`EXT_feature_metadata`](https://github.com/CesiumGS/glTF/tree/feature-metadata/extensions/2.0/Vendor/EXT_feature_metadata) with binary buffer storage for property arrays.
+
+The full JSON schemas can be found [here](schema).
+
+## Examples
+
+See [metadata-sidecar](./examples/metadata-sidecar) and [metadata-embedded](./examples/metadata-embedded).

--- a/extensions/3DTILES_feature_metadata/examples/metadata-embedded/tile.gltf
+++ b/extensions/3DTILES_feature_metadata/examples/metadata-embedded/tile.gltf
@@ -1,0 +1,197 @@
+{
+  "accessors": [
+    {
+      "name": "Positions",
+      "bufferView": 6,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 8,
+      "type": "VEC3"
+    },
+    {
+      "name": "Colors",
+      "bufferView": 7,
+      "byteOffset": 0,
+      "componentType": 5121,
+      "count": 8,
+      "stride": 4,
+      "type": "VEC3"
+    },
+    {
+      "name": "Feature IDs",
+      "bufferView": 8,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 8,
+      "type": "SCALAR"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 16
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 16,
+      "byteLength": 8
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 24,
+      "byteLength": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 36,
+      "byteLength": 24
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 60,
+      "byteLength": 32
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 92,
+      "byteLength": 16
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 108,
+      "byteLength": 96
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 204,
+      "byteLength": 32
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 236,
+      "byteLength": 32
+    }
+  ],
+  "buffer": [
+    {
+      "byteLength": 268,
+      "uri": "external.bin"
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "COLOR_0": 1,
+            "_FEATURE_ID_0": 2
+          },
+          "mode": 0,
+          "extensions": {
+            "EXT_feature_metadata": {
+              "featureMappings": [
+                {
+                  "featureCollection": 0,
+                  "featureIds": {
+                    "constant": 0,
+                    "vertexStride": 1
+                  }
+                },
+                {
+                  "featureCollection": 1,
+                  "featureIds": {
+                    "attribute": "_FEATURE_ID_0"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "extensionsUsed": [
+    "EXT_feature_metadata"
+  ],
+  "extensions": {
+    "EXT_feature_metadata": {
+      "extras": {
+        "draftVersion": "0.0.0"
+      },
+      "featureTypes": [
+        {
+          "name": "LAS point",
+          "semantic": "_LAS_POINT",
+          "properties": [
+            {
+              "name": "Intensity",
+              "semantic": "_INTENSITY",
+              "valueType": "UINT16",
+              "normalized": true
+            },
+            {
+              "name": "Classification",
+              "semantic": "_CLASSIFICATION",
+              "valueType": "UINT8"
+            }
+          ]
+        },
+        {
+          "name": "Building",
+          "semantic": "_BUILDING",
+          "properties": [
+            {
+              "name": "Building ID",
+              "valueType": "UINT32"
+            },
+            {
+              "name": "Coordinates",
+              "valueType": "FLOAT32",
+              "elementType": "ARRAY",
+              "valuesPerElement": 2
+            },
+            {
+              "name": "Name",
+              "semantic": "NAME",
+              "valueType": "STRING"
+            }
+          ]
+        }
+      ],
+      "featureCollections": [
+        {
+          "featureType": 0,
+          "featureCount": 8,
+          "arrayLengths": 8,
+          "propertyArrays": [
+            {
+              "bufferView": 0
+            },
+            {
+              "bufferView": 1
+            }
+          ]
+        },
+        {
+          "featureType": 1,
+          "featureCount": 3,
+          "arrayLengths": 3,
+          "propertyArrays": [
+            {
+              "bufferView": 2
+            },
+            {
+              "bufferView": 3
+            },
+            {
+              "bufferView": 4,
+              "offsetBufferView": 5
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/extensions/3DTILES_feature_metadata/examples/metadata-embedded/tileset.json
+++ b/extensions/3DTILES_feature_metadata/examples/metadata-embedded/tileset.json
@@ -1,0 +1,71 @@
+{
+  "asset": {
+    "version": "1.0"
+  },
+  "extensionsUsed": ["3DTILES_feature_metadata", "3DTILES_content_gltf"],
+  "extensionsRequired": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_feature_metadata": {
+      "extras": {
+        "draftVersion": "0.0.0"
+      },
+      "featureTypes": [
+        {
+          "name": "LAS point",
+          "semantic": "_LAS_POINT",
+          "properties": [
+            {
+              "name": "Intensity",
+              "semantic": "_INTENSITY",
+              "valueType": "UINT16",
+              "normalized": true
+            },
+            {
+              "name": "Classification",
+              "semantic": "_CLASSIFICATION",
+              "valueType": "UINT8"
+            }
+          ]
+        },
+        {
+          "name": "Building",
+          "semantic": "_BUILDING",
+          "properties": [
+            {
+              "name": "Building ID",
+              "valueType": "UINT32"
+            },
+            {
+              "name": "Coordinates",
+              "valueType": "FLOAT32",
+              "elementType": "ARRAY",
+              "valuesPerElement": 2
+            },
+            {
+              "name": "Name",
+              "semantic": "NAME",
+              "valueType": "STRING"
+            }
+          ]
+        }
+      ]
+    },
+    "3DTILES_content_gltf": {
+      "extras": {
+        "draftVersion": "0.0.0"
+      },
+      "gltfExtensionsUsed": ["EXT_feature_metadata"]
+    }
+  },
+  "geometricError": 240,
+  "root": {
+    "boundingVolume": {
+      "region": [-1.31972, 0.69884, -1.31964, 0.6989, 0, 88]
+    },
+    "geometricError": 0,
+    "refine": "ADD",
+    "content": {
+      "uri": "tile.gltf"
+    }
+  }
+}

--- a/extensions/3DTILES_feature_metadata/examples/metadata-sidecar/metadata.json
+++ b/extensions/3DTILES_feature_metadata/examples/metadata-sidecar/metadata.json
@@ -1,0 +1,116 @@
+{
+  "binaryBuffers": {
+    "bufferViews": [
+      {
+        "buffer": 0,
+        "byteOffset": 0,
+        "byteLength": 16
+      },
+      {
+        "buffer": 0,
+        "byteOffset": 16,
+        "byteLength": 8
+      },
+      {
+        "buffer": 0,
+        "byteOffset": 24,
+        "byteLength": 12
+      },
+      {
+        "buffer": 0,
+        "byteOffset": 36,
+        "byteLength": 24
+      },
+      {
+        "buffer": 0,
+        "byteOffset": 60,
+        "byteLength": 32
+      },
+      {
+        "buffer": 0,
+        "byteOffset": 92,
+        "byteLength": 16
+      }
+    ],
+    "buffers": [
+      {
+        "uri": "external.bin",
+        "byteLength": 108
+      }
+    ]
+  },
+  "featureMetadata": {
+    "featureTypes": [
+      {
+        "name": "LAS point",
+        "semantic": "_LAS_POINT",
+        "properties": [
+          {
+            "name": "Intensity",
+            "semantic": "_INTENSITY",
+            "valueType": "UINT16",
+            "normalized": true
+          },
+          {
+            "name": "Classification",
+            "semantic": "_CLASSIFICATION",
+            "valueType": "UINT8"
+          }
+        ]
+      },
+      {
+        "name": "Building",
+        "semantic": "_BUILDING",
+        "properties": [
+          {
+            "name": "Building ID",
+            "valueType": "UINT32"
+          },
+          {
+            "name": "Coordinates",
+            "valueType": "FLOAT32",
+            "elementType": "ARRAY",
+            "valuesPerElement": 2
+          },
+          {
+            "name": "Name",
+            "semantic": "NAME",
+            "valueType": "STRING"
+          }
+        ]
+      }
+    ],
+    "featureCollections": [
+      {
+        "featureType": 0,
+        "featureCount": 8,
+        "arrayLengths": 8,
+        "propertyArrays": [
+          {
+            "bufferView": 0
+          },
+          {
+            "bufferView": 1
+          }
+        ]
+      },
+      {
+        "featureType": 1,
+        "featureCount": 3,
+        "arrayLengths": 3,
+        "propertyArrays": [
+          {
+            "bufferView": 2
+          },
+          {
+            "bufferView": 3
+          },
+          {
+            "bufferView": 4,
+            "offsetBufferView": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/extensions/3DTILES_feature_metadata/examples/metadata-sidecar/tile.gltf
+++ b/extensions/3DTILES_feature_metadata/examples/metadata-sidecar/tile.gltf
@@ -1,0 +1,95 @@
+{
+  "accessors": [
+    {
+      "name": "Positions",
+      "bufferView": 0,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 8,
+      "type": "VEC3"
+    },
+    {
+      "name": "Colors",
+      "bufferView": 1,
+      "byteOffset": 0,
+      "componentType": 5121,
+      "count": 8,
+      "stride": 4,
+      "type": "VEC3"
+    },
+    {
+      "name": "Feature IDs",
+      "bufferView": 2,
+      "byteOffset": 0,
+      "componentType": 5126,
+      "count": 8,
+      "type": "SCALAR"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 96
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 96,
+      "byteLength": 32
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 128,
+      "byteLength": 32
+    }
+  ],
+  "buffer": [
+    {
+      "byteLength": 160,
+      "uri": "external.bin"
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "COLOR_0": 1,
+            "_FEATURE_ID_0": 2
+          },
+          "mode": 0,
+          "extensions": {
+            "EXT_feature_metadata": {
+              "featureMappings": [
+                {
+                  "featureCollection": 0,
+                  "featureIds": {
+                    "constant": 0,
+                    "vertexStride": 1
+                  }
+                },
+                {
+                  "featureCollection": 1,
+                  "featureIds": {
+                    "attribute": "_FEATURE_ID_0"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "extensionsUsed": [
+    "EXT_feature_metadata"
+  ],
+  "extensions": {
+    "EXT_feature_metadata": {
+      "extras": {
+        "draftVersion": "0.0.0"
+      }
+    }
+  }
+}

--- a/extensions/3DTILES_feature_metadata/examples/metadata-sidecar/tileset.json
+++ b/extensions/3DTILES_feature_metadata/examples/metadata-sidecar/tileset.json
@@ -1,0 +1,76 @@
+{
+  "asset": {
+    "version": "1.0"
+  },
+  "extensionsUsed": ["3DTILES_feature_metadata", "3DTILES_content_gltf"],
+  "extensionsRequired": ["3DTILES_content_gltf"],
+  "extensions": {
+    "3DTILES_feature_metadata": {
+      "extras": {
+        "draftVersion": "0.0.0"
+      },
+      "featureTypes": [
+        {
+          "name": "LAS point",
+          "semantic": "_LAS_POINT",
+          "properties": [
+            {
+              "name": "Intensity",
+              "semantic": "_INTENSITY",
+              "valueType": "UINT16",
+              "normalized": true
+            },
+            {
+              "name": "Classification",
+              "semantic": "_CLASSIFICATION",
+              "valueType": "UINT8"
+            }
+          ]
+        },
+        {
+          "name": "Building",
+          "semantic": "_BUILDING",
+          "properties": [
+            {
+              "name": "Building ID",
+              "valueType": "UINT32"
+            },
+            {
+              "name": "Coordinates",
+              "valueType": "FLOAT32",
+              "elementType": "ARRAY",
+              "valuesPerElement": 2
+            },
+            {
+              "name": "Name",
+              "semantic": "NAME",
+              "valueType": "STRING"
+            }
+          ]
+        }
+      ]
+    },
+    "3DTILES_content_gltf": {
+      "extras": {
+        "draftVersion": "0.0.0"
+      },
+      "gltfExtensionsUsed": ["EXT_feature_metadata"]
+    }
+  },
+  "geometricError": 240,
+  "root": {
+    "boundingVolume": {
+      "region": [-1.31972, 0.69884, -1.31964, 0.6989, 0, 88]
+    },
+    "geometricError": 0,
+    "refine": "ADD",
+    "content": {
+      "uri": "tile.gltf",
+      "extensions": {
+        "3DTILES_feature_metadata": {
+          "uri": "metadata.json"
+        }
+      }
+    }
+  }
+}

--- a/extensions/3DTILES_feature_metadata/schema/content.3DTILES_feature_metadata.schema.json
+++ b/extensions/3DTILES_feature_metadata/schema/content.3DTILES_feature_metadata.schema.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Content feature metadata",
+    "type": "object",
+    "description": "Links tile content with its feature metadata.",
+    "properties": {
+        "uri": {
+            "type": "string",
+            "format" : "uriref",
+            "description": "The uri that point to the content's feature metadata."
+        },
+        "extensions": {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
+        }
+    },
+    "required" : ["uri"]
+}

--- a/extensions/3DTILES_feature_metadata/schema/external.featureMetadata.schema.json
+++ b/extensions/3DTILES_feature_metadata/schema/external.featureMetadata.schema.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "External feature metadata",
+    "type": "object",
+    "description": "Feature metadata for tile content.",
+    "properties": {
+        "featureMetadata": {
+            "type": "object",
+            "description": "An object that defines feature types and feature property arrays. The schema mirrors gltf.EXT_feature_metadata.schema.json in https://github.com/CesiumGS/glTF/blob/feature-metadata/extensions/2.0/Vendor/EXT_feature_metadata/"
+        },
+        "binaryBuffers": {
+            "type": "array",
+            "description": "An object that provides access to binary buffers for property array storage. The schema mirrors tileset.3DTILES_binary_buffers.schema.json in https://github.com/CesiumGS/3d-tiles/blob/3DTILES_binary_buffers/extensions/3DTILES_binary_buffers/"
+        },
+        "extensions": {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
+        }
+    },
+    "required" : ["featureMetadata", "binaryBuffers"]
+}

--- a/extensions/3DTILES_feature_metadata/schema/tileset.3DTILES_feature_metadata.schema.json
+++ b/extensions/3DTILES_feature_metadata/schema/tileset.3DTILES_feature_metadata.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Feature metadata",
+    "type": "object",
+    "description": "High-level summary of feature metadata in the tileset.",
+    "properties": {
+        "featureTypes": {
+            "type": "array",
+            "description": "Lists feature types referenced by tiles in the tileset. Mirrors featureType.property.schema.json in https://github.com/CesiumGS/glTF/blob/feature-metadata/extensions/2.0/Vendor/EXT_feature_metadata/",
+            "items": {
+                "type": "object"
+            },
+            "minItems": 1
+        },
+        "extensions": {
+            "$ref": "extension.schema.json"
+        },
+        "extras" : {
+            "$ref": "extras.schema.json"
+        }
+    }
+}


### PR DESCRIPTION
Direct Link|Draft Version|Changes
--|--|--
[`3DTILES_feature_metadata`](https://github.com/CesiumGS/3d-tiles/blob/3DTILES_feature_metadata/extensions/3DTILES_feature_metadata) | 0.0.0 | Initial draft

This extension lists the feature types present in a tileset and provides a mechanism for storing feature metadata alongside tile content (glTF or non-glTF content). Feature metadata mirrors the [`EXT_feature_metadata`](https://github.com/CesiumGS/glTF/tree/feature-metadata/extensions/2.0/Vendor/EXT_feature_metadata) glTF extension.

The top-level `3DTILES_feature_metadata` extension lists feature types that are referenced by tiles within the tileset. A client may use this information to populate a UI, filter metadata requests, or generate styles on-the-fly.

To do:

* [ ] Clarify relationship between glTF feature metadata, sidecar feature metadata, and 3D Tiles feature metadata
* [ ] Add implicit tiling example
* [ ] Add ability to point to an external file for feature type definitions
    * [ ] Can this external file include feature types not present in this tileset JSON?