### PR TITLE
Add Texture schema to Cesium 3D Metadata Spec

### DIFF
--- a/specification/Metadata/0.0.0/README.md
+++ b/specification/Metadata/0.0.0/README.md
@@ -273,8 +273,7 @@ This is useful for continuous properties such as elevation, vegetation index, ve
 }
 ```
 
-**Note**: The method of selecting a texture is implementation-defined. The above example is based on a glTF implementation where `index` selects a texture and `texCoord` selects the texture coordinates. Other implementations may do this in
-alternate ways.
+**Note**: The method of selecting a texture is implementation-defined. The above example is based on a glTF implementation where `index` selects a texture and `texCoord` selects the texture coordinates. Other implementations may do select a texture by other means.
 
 #### Comparison of Encodings
 

--- a/specification/Metadata/0.0.0/README.md
+++ b/specification/Metadata/0.0.0/README.md
@@ -244,7 +244,7 @@ The metadata texture encoding serves a different purpose than the other encoding
 
 This is useful for continuous properties such as elevation, vegetation index, vector fields, and many other properties that vary with position. It also can be used for better compression of metadata values in some cases.
 
-```json
+```jsonc
 {
   "classes": {
     "vegetation": {
@@ -261,17 +261,20 @@ This is useful for continuous properties such as elevation, vegetation index, ve
       "class": "vegetation",
       "properties": {
         "vegetationIndex": {
+          "channels": "r",
           "texture": {
             "index": 0,
             "texCoord": 0
-          },
-          "channels": "r"
+          }
         }
       }
     }
   }
 }
 ```
+
+**Note**: The method of selecting a texture is implementation-defined. The above example is based on a glTF implementation where `index` selects a texture and `texCoord` selects the texture coordinates. Other implementations may do this in
+alternate ways.
 
 #### Comparison of Encodings
 
@@ -1154,6 +1157,8 @@ In the following example, a single-channel image is used to encode surface tempe
 }
 ```
 
+**Note**: in the above example, the `texture` object is based on a glTF implementation. See [Implementation Notes](#implementation-notes) below.
+
 #### Array Textures
 
 Fixed-size (but not variable-size) arrays can be stored as a multi-channel texture. This is useful for encoding vector-valued properties.
@@ -1193,11 +1198,15 @@ The example below demonstrates representing a `vec3` using a 3-channel image. Th
 }
 ```
 
+**Note**: in the above example, the `texture` object is based on a glTF implementation. See [Implementation Notes](#implementation-notes) below.
+
 ![vec3 metadata texture](figures/vec3-texture.jpg)
 
 #### Implementation Notes
 
 In implementations that only support PNG and JPEG images such as glTF, the available data types for textures is somewhat limited. Only data types based on `UINT8` (including normalized `UINT8` and/or fixed-length arrays) are straightforward to implement for PNG/JPEG images. Other data types such as floats or signed integers may require additional extensions of the underlying data format. Cases like these are left to the implementation to define.
+
+Furthermore, depending on the implementation, the method of specifying a texture and texture coordinates may vary. A glTF-based implementation may index into the `textures` array. A Cesium 3D Tiles-based implementation may do this differently.
 
 ## Glossary
 

--- a/specification/Metadata/0.0.0/schema/index.schema.json
+++ b/specification/Metadata/0.0.0/schema/index.schema.json
@@ -20,6 +20,14 @@
         "$ref": "instanceTable.schema.json"
       }
     },
+    "metadataTextures": {
+      "type": "object",
+      "description": "A dictionary, where each key is a metadata texture ID and each value is an object defining the metadata texture",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "metadataTexture.schema.json"
+      }
+    },
     "extensions": {},
     "extras": {}
   }

--- a/specification/Metadata/0.0.0/schema/metadataTexture.schema.json
+++ b/specification/Metadata/0.0.0/schema/metadataTexture.schema.json
@@ -2,8 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "Metadata Texture",
     "type": "object",
-    "description": "Instances whose properties are stored directly in the texture designated by a class and property values stored in texture channels. This requires a class but not a feature table.",
-    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "description": "Instances whose properties are stored directly in the texture designated by a class and property values stored in texture channels.",
     "properties": {
         "class": {
             "type": "string",

--- a/specification/Metadata/0.0.0/schema/metadataTexture.schema.json
+++ b/specification/Metadata/0.0.0/schema/metadataTexture.schema.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "Metadata Texture",
+    "type": "object",
+    "description": "Instances whose properties are stored directly in the texture designated by a class and property values stored in texture channels. This requires a class but not a feature table.",
+    "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
+    "properties": {
+        "class": {
+            "type": "string",
+            "description": "The ID of the class."
+        },
+        "properties": {
+            "type": "object",
+            "description": "A dictionary, where each key corresponds to a property ID in the class's `properties` dictionary and each value describes the texture channels containing property data.",
+            "minProperties": 1,
+            "additionalProperties" : {
+                "$ref": "textureAccessor.schema.json"
+            }
+        },
+        "extensions": { },
+        "extras": { }
+    },
+    "required": [ "class", "properties" ]
+}

--- a/specification/Metadata/0.0.0/schema/textureAccessor.schema.json
+++ b/specification/Metadata/0.0.0/schema/textureAccessor.schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "A description of how to access data values from the color channels of a texture",
+    "type": "object",
+    "properties": {
+        "channels": {
+            "type": "string",
+            "pattern": "^[rgba]{1,4}$",
+            "description": "Texture channels containing property values according to the property `componentType`. Channels are labeled by `rgba` and are swizzled with a string of 1-4 characters."
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}

--- a/specification/Metadata/0.0.0/schema/textureAccessor.schema.json
+++ b/specification/Metadata/0.0.0/schema/textureAccessor.schema.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "A description of how to access data values from the color channels of a texture",
+    "title": "Texture Accessor",
+    "description": "A description of how to access data values from the color channels of a texture. The method of selecting a texture is implementation-defined.",
     "type": "object",
     "properties": {
         "channels": {


### PR DESCRIPTION
This adds a couple missing schema files to the `schema` folder, and adds a few notes in the README to say that some examples are glTF specific (as `texture` is not actually part of this schema!)

@lilleyse could you review?