### PR TITLE
Revise core metadata spec

### DIFF
--- a/specification/Metadata/0.0.0/README.md
+++ b/specification/Metadata/0.0.0/README.md
@@ -42,7 +42,6 @@ Draft
       - [Basic Types](#basic-types-1)
       - [Bit Depth of Numeric Types](#bit-depth-of-numeric-types)
       - [Array Types](#array-types)
-      - [Blob Base64 Encoding](#blob-base64-encoding)
       - [Fixed-length Strings and Blobs](#fixed-length-strings-and-blobs)
       - [Optional and Default Values](#optional-and-default-values)
       - [Single Instance Shorthand](#single-instance-shorthand)
@@ -540,53 +539,10 @@ The following example shows the usage for both fixed and variable size arrays:
 }
 ```
 
-#### Blob Base64 Encoding
-
-A Blob (Binary Large OBject) is a sequence of arbitrary bytes used for storing user-defined information. This is a flexible format for application-specific data. Some examples where this can be useful:
-
-* A CAD design could be attached to a 3D model of a building.
-* Points in a point cloud can be tagged with a proprietary format.
-* If a property contains sensitive information, the values could be encrypted and stored as a blob.
-
-Unlike the other data types, binary blobs do not have a straightforward JSON encoding. This is because JSON uses UTF-8 encoding, not arbitrary binary data. Raw binary values are often invalid UTF-8 sequences. This spec requires that binary blobs are Base64 encoded.
-
-Base64 is easy to transmit as it only uses ASCII characters, but is not very efficient for storage. If large blobs are needed, it is highly recommended to use the binary metadata encoding instead.
-
-```json
-{
-  "classes": {
-    "basicTypes": {
-      "properties": {
-        "blobProperty": {
-          "type": "BLOB"
-        }
-      }
-    }
-  },
-  "instanceTables": {
-    "basicTypesTable": {
-      "class": "basicTypes",
-      "count": 3,
-      "properties": {
-        "blobProperty": {
-          "values": [
-            "TG9va2luZyBmb3Igc2VjcmV0cw==",
-            "WW91IGRlY29kZWQgdGhlIG1lc3NhZ2U=",
-            "QnV0IG5vbmUgY291bGQgYmUgZm91bmQ="
-          ]
-        }
-      }
-    }
-  }
-}
-```
-
 #### Fixed-length Strings and Blobs
 
 In some cases, strings have a known, fixed length. For example, an application may require dates to be entered in `YYYYMMDD` format, which will fit in exactly 8 bytes. For this,
 the specification provides a `stringByteLength` property. In the JSON encoding, this byte length refers to the length of the string when UTF-8 encoded, regardless of how it is displayed.
-
-`blobByteLength` is similar, but used for binary data. The length is measured as the _decoded_ binary length, not the length of the Base64 string.
 
 ```json
 {
@@ -597,10 +553,6 @@ the specification provides a `stringByteLength` property. In the JSON encoding, 
           "name": "Date (YYYYMMDD)",
           "type": "STRING",
           "stringByteLength": 8
-        },
-        "fixedBlobProperty": {
-          "type": "BLOB",
-          "blobByteLength": 4
         }
       }
     }
@@ -615,13 +567,6 @@ the specification provides a `stringByteLength` property. In the JSON encoding, 
             "20201002",
             "20201103",
             "20201105"
-          ]
-        },
-        "blobProperty": {
-          "values": [
-            "AAECAw==",
-            "BAUGBw==",
-            "CAkKCw=="
           ]
         }
       }

--- a/specification/Metadata/0.0.0/README.md
+++ b/specification/Metadata/0.0.0/README.md
@@ -21,6 +21,7 @@ Draft
 <!-- omit in toc -->
 ## Table of Contents
 
+- [Introduction](#introduction)
 - [Overview](#overview)
 - [Concepts](#concepts)
   - [Classes](#classes)
@@ -57,6 +58,14 @@ Draft
     - [Array Textures](#array-textures)
     - [Implementation Notes](#implementation-notes)
 - [Glossary](#glossary)
+
+## Introduction
+
+OUTLINE:
+- key benefits:
+  - standardized semantics makes it easier to implement UIs
+  - runtime efficiency for large datasets 
+  - texel metadata is even more fine-grained than per-vertex or per-triangle
 
 ## Overview
 
@@ -1159,17 +1168,18 @@ Furthermore, depending on the implementation, the method of specifying a texture
 
 ## Glossary
 
-* **feature** - A combination of a single piece of geometry and corresponding metadata.
-* **geometry** - Any geometric entity such as a vertex, texel, or larger structures like meshes or patches of texels.
-* **metadata** - Application-specific properties associated with geometry.
-* **class** - A high-level description of one or more associated pieces of metadata (called properties).
-* **property** - A description of a single piece of metadata. This includes information such as a datatype.
-* **instance** - A concrete representation of a class consisting of a value for every property.
-* **instance table** - A mapping of instance IDs to metadata for each instance. The values are stored in parallel property arrays.
 * **buffer** - a contiguous sequence of bytes used for storing binary data. This is equivalent to the [glTF `buffer` concept](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#buffers-and-buffer-views).
 * **buffer view** or `bufferView` - A subsequence of a buffer that represents a single array. A buffer view is completely contained within a buffer. This is equivalent to the [glTF `bufferView` concept](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#buffers-and-buffer-views), though applied to a broader set of data types.
-* **property array** - A single array that stores values for one property.  
+* **class** - A high-level description of one or more associated pieces of metadata (called properties).
+* **component** (of an element) - For elements of type `ARRAY`, the values contained within are called components. In other words, a property array contains elements which contain components.
 * **element** (of a property array) - a single entry of a property array. This stores the value of one property for a single instance.
-* **component** (of an element) - For elements of type `ARRAY`, the values contained within are called components. In other words, a property array contains elements which contain components. 
-* **metadata texture** - A texture that represents a property directly, no instance table needed
 * **encoding** - A concrete method of storing metadata in a format such as JSON, binary, or textures.
+* **instance** - A concrete encoding of a class consisting of a value for every property of the class.
+* **instance table** - A table of metadata values indexed by instance IDs. The columns of the table are a set of parallel property arrays.
+* **metadata** - Additional application-specific properties in a structured format.
+* **metadata texture** - A texture that represents property values directly without need for an instance table.
+* **property** - A description of a single piece of metadata. This includes information such as a datatype.
+* **property array** - A single array that stores values for one property.
+
+
+

--- a/specification/Metadata/0.0.0/README.md
+++ b/specification/Metadata/0.0.0/README.md
@@ -60,6 +60,7 @@ Draft
     - [Array Textures](#array-textures)
     - [Implementation Notes](#implementation-notes)
 - [Glossary](#glossary)
+- [Appendix A: Comparison with Batch Tables](#appendix-a-comparison-with-batch-tables)
 
 ## Introduction
 
@@ -1257,5 +1258,24 @@ Furthermore, depending on the implementation, the method of specifying a texture
 * **property** - A description of a single piece of metadata. This includes information such as a datatype.
 * **property array** - A single array that stores values for one property.
 
+## Appendix A: Comparison with Batch Tables
 
+Cesium 3D Tiles 1.0 defines a concept of [batch tables](https://github.com/CesiumGS/3d-tiles/blob/master/specification/TileFormats/BatchTable/README.md) for adding application-specific properties to 3D Tiles content files. Batch tables were the precursor to instance tables.
 
+Batch tables and instance tables share the following in common:
+
+* Both support integers, floats, and vector types
+* Property values are accessed by an integer ID
+
+Key differences:
+
+* instance tables add several new data types: `UINT64`, `INT64`, `FLOAT16`, `BOOLEAN`, `STRING` and `ARRAY`
+* Numeric types now name the bits explicitly, i.e. `INT8` `INT16`, `INT32` rather than `BYTE`, `SHORT`, `INT`
+* The `ARRAY` type of instance tables allows for larger vectors than `VEC4`
+* The terminology is different:
+
+| Batch Table Terminology | Instance Table Terminology |
+|-------------------------|----------------------------|
+| feature                 | instance                   |
+| property                | property                   |
+| batch ID                | instance ID                |

--- a/specification/Metadata/0.0.0/README.md
+++ b/specification/Metadata/0.0.0/README.md
@@ -107,15 +107,18 @@ The following example shows the basics of how classes describe the data types, w
     "tree": {
       "properties": {
         "height": {
-          "name": "Height (m)",
+          "name": "Height",
+          "description": "Height of the tree in meters",
           "type": "FLOAT32",
         },
         "age": {
-          "name": "Age (years)",
+          "name": "Age",
+          "description": "Age of the tree in years",
           "type": "UINT16"
         },
         "leafColor": {
           "name": "Leaf Color",
+          "description": "The color of the tree's leaves.",
           "type": "STRING",
           "optional": true,
           "default": "green"
@@ -152,7 +155,8 @@ Below is an example of a well-formed instance table representing a class.
           "type": "STRING"
         },
         "height": {
-          "name": "Building Height (m)",
+          "name": "Building Height",
+          "description": "Height of the building in meters",
           "type": "FLOAT32"
         }
       }
@@ -318,7 +322,8 @@ Both classes and properties can be annotated with display names and descriptions
       "description": "Sailing ships seen in the ocean",
       "properties": {
         "length": {
-          "name": "Length (m)",
+          "name": "Length",
+          "description": "Length of the ship from bow to stern in meters",
           "type": "FLOAT64"
         },
         "name": {
@@ -332,7 +337,8 @@ Both classes and properties can be annotated with display names and descriptions
       "description": "Fish found in the ocean",
       "properties": {
         "length": {
-          "name": "Length (cm)",
+          "name": "Length",
+          "description": "Length of the fish in centimeters",
           "type": "FLOAT32"
         }
       }
@@ -723,11 +729,13 @@ Here is an example of how to define an instance table for basic integer and floa
     "tree": {
       "properties": {
         "height": {
-          "name": "Height (m)",
+          "name": "Height",
+          "description": "Height of tree in meters",
           "type": "FLOAT64"
         },
         "leafCount": {
-          "name": "Number of Leaves (estimated)",
+          "name": "Number of Leaves",
+          "description": "Estimated number of leaves on this tree",
           "type": "UINT32"
         }
       }
@@ -1076,7 +1084,8 @@ In the following example, a single-channel image is used to encode surface tempe
     "ocean": {
       "properties": {
         "temperature": {
-          "name": "Surface Temperature (°C)",
+          "name": "Surface Temperature",
+          "description": "Temperature at the surface of the ocean in (°C)",
           "type": "UINT8",
           "normalized": "true"
         }

--- a/specification/Metadata/0.0.0/README.md
+++ b/specification/Metadata/0.0.0/README.md
@@ -92,10 +92,7 @@ For a complete list of vocabulary used, see the [Glossary](#glossary)
 
 A **class** describes a collection of related pieces of metadata called **properties** and their respective data types. In some ways, this is similar to describing the columns of a database table. However, this analogy is not completely applicable, as this specification allows for texture storage, not just columnar formats.
 
-A class definition describes what metadata is available. However, it does not describe how this metadata is stored. The section on [Instances](#instances) will provide more information.
-
 The following example shows the basics of how classes describe the data types, without describing where the data is stored. The following section will show how to connect these classes to the actual metadata in various storage formats.
-
 
 ```json
 {
@@ -139,8 +136,6 @@ The following example shows the basics of how classes describe the data types, w
 ```
 
 Above, we define a `building` class to describe the street address and height of various buildings in a 3D scene. Likewise, the `tree` class describes trees that have a height, age, and leaf color.
-
-For a more detailed description of how classes are defined, see the [Class Definitions](#class-definitions) section below.
 
 ### Instances
 
@@ -187,8 +182,6 @@ Below is an example of a well-formed instance table representing a class.
 }
 ```
 
-A brief overview of each encoding follows to explain the concepts. The full details can be found further below in the [Storage Encodings](#storage-encodings) section.
-
 #### Instance Tables
 
 An instance table is a mapping of **instance IDs** to metadata values which are stored in parallel arrays called **property arrays**. Instance IDs are simply integer indices into these arrays. The `i-th` value of every property array in an instance table together makes up the metadata for the `i-th` instance. 
@@ -225,8 +218,7 @@ defined above.
 
 Binary encoding is the preferred encoding in most cases since it is designed for storage and runtime efficiency. It is designed with large datasets in mind.
 
-The binary encoding is more involved than the JSON, as there are many considerations about how to pack and align the data efficiently. A detailed discussion of this can be found in the other [Binary Encoding](#binary-encoding-1) section further below
-in this document. For now, here is a small example to show how the same `building` class described above would be described with an instance table.
+Here is a small example to show how the same `building` class described above would be described with an instance table.
 
 ```json
 {
@@ -407,7 +399,7 @@ For vector-valued types such as a `vec3` or `mat4` in OpenGL, use a fixed-size a
 
 ### Optional and Default Properties
 
-Sometimes, it is desirable to mark cases where no data can be found. This can be accomplished by setting `optional: true` in the property definition. If a property has a default value, set `optional: true` and set a value for `default`. Default values are expressed as a single value in the same format as in the [JSON Encoding](#json-encoding).
+Sometimes, it is desirable to mark cases where no data can be found. This can be accomplished by setting `optional: true` in the property definition. If a property has a default value, set `optional: true` and set a value for `default`.
 
 Example:
 

--- a/specification/Metadata/0.0.0/README.md
+++ b/specification/Metadata/0.0.0/README.md
@@ -75,6 +75,8 @@ Guiding principles for this specification include:
 - Design a data format that allows for runtime efficiency, even for large datasets.
 - Keep class definitions separate from instantiation. This allows for greater flexibility of data formats, and allows for reuse of metadata definitions.
 
+For a complete list of vocabulary used, see the [Glossary](#glossary)
+
 ## Concepts
 
 ### Classes
@@ -179,7 +181,7 @@ A brief overview of each encoding follows to explain the concepts. The full deta
 
 An instance table is a mapping of **instance IDs** to metadata values which are stored in parallel arrays called **property arrays**. Instance IDs are simply integer indices into these arrays. The `i-th` value of every property array in an instance table together makes up the metadata for the `i-th` instance. 
 
-The instance table has two possible representations on disk: JSON and binary. The following sections compare the two encodings.
+The instance table has two possible representations: JSON and binary. The following sections compare the two encodings.
 
 #### JSON Encoding
 
@@ -378,7 +380,7 @@ For vector-valued types such as a `vec3` or `mat4` in OpenGL, use a fixed-size a
         },
         "modelMatrix": {
           "name": "Model Matrix",
-          "description": "mat4 example representing a custom matrix field",
+          "description": "Example of a 4x4 matrix type",
           "type": "ARRAY",
           "componentType": "FLOAT32",
           "componentCount": 16
@@ -1048,7 +1050,7 @@ the _bit_ offsets, rather than the usual byte offsets. Again, the offsets are co
 
 #### Binary Alignment Rules
 
-Due to the possibility of 64-bit data types, this extension requires that each `bufferView` is aligned to a multiple of 8 bytes for efficient reads. This alignment requirement is always measured from the start of the binary file. This alignment requirement only applies to the start of each bufferView used for metadata.
+Due to the possibility of 64-bit data types, each `bufferView` must be aligned to a multiple of 8 bytes for efficient reads. This alignment requirement is always measured from the start of the binary file. This alignment requirement only applies to the start of each bufferView used for metadata.
 
 To meet this alignment requirement, padding or other data must go between the `bufferView`s so that each starts on an 8-byte boundary.
 
@@ -1164,4 +1166,4 @@ Furthermore, depending on the implementation, the method of specifying a texture
 * **element** (of a property array) - a single entry of a property array. This stores the value of one property for a single instance.
 * **component** (of an element) - For elements of type `ARRAY`, the values contained within are called components. In other words, a property array contains elements which contain components. 
 * **metadata texture** - A texture that represents a property directly, no instance table needed
-* **encoding** - A method of storing metadata on disk in a format such as JSON, binary, or texture encodings.
+* **encoding** - A concrete method of storing metadata in a format such as JSON, binary, or textures.

--- a/specification/Metadata/0.0.0/README.md
+++ b/specification/Metadata/0.0.0/README.md
@@ -1,7 +1,9 @@
+<!-- omit in toc -->
 # Cesium 3D Metadata Specification
 
 **Version 0.0.0** November 6, 2020
 
+<!-- omit in toc -->
 ## Contributors
 
 * Peter Gagliardi, Cesium
@@ -11,59 +13,54 @@
 * Samuel Vargas, Cesium
 * Patrick Cozzi, Cesium
 
+<!-- omit in toc -->
 ## Status
 
 Draft
 
+<!-- omit in toc -->
 ## Table of Contents
 
-- [Cesium 3D Metadata Specification](#cesium-3d-metadata-specification)
-  - [Contributors](#contributors)
-  - [Status](#status)
-  - [Table of Contents](#table-of-contents)
-  - [Abstract](#abstract)
-  - [Introduction](#introduction)
-  - [Concepts](#concepts)
-    - [Classes](#classes)
-    - [Instances](#instances)
-      - [Instance Tables](#instance-tables)
-      - [JSON Encoding](#json-encoding)
-      - [Binary Encoding](#binary-encoding)
-      - [Metadata Texture Encoding](#metadata-texture-encoding)
-      - [Comparison of Encodings](#comparison-of-encodings)
-    - [Separate Class Definition from Instantiation](#separate-class-definition-from-instantiation)
-  - [Class Definitions](#class-definitions)
-    - [Basic Types](#basic-types)
-    - [Normalized Properties](#normalized-properties)
-    - [Arrays](#arrays)
-    - [Optional and Default Properties](#optional-and-default-properties)
-  - [Storage Encodings](#storage-encodings)
-    - [JSON Encoding](#json-encoding-1)
-      - [Basic Types](#basic-types-1)
-      - [Bit Depth of Numeric Types](#bit-depth-of-numeric-types)
-      - [Array Types](#array-types)
-      - [Fixed-length Strings and Blobs](#fixed-length-strings-and-blobs)
-      - [Optional and Default Values](#optional-and-default-values)
-      - [Single Instance Shorthand](#single-instance-shorthand)
-    - [Binary Encoding](#binary-encoding-1)
-      - [Numeric Types](#numeric-types)
-      - [Strings and Blobs](#strings-and-blobs)
-      - [Fixed-length Strings and Blobs](#fixed-length-strings-and-blobs-1)
-      - [Arrays](#arrays-1)
-      - [Variable-size Arrays](#variable-size-arrays)
-      - [Boolean Data](#boolean-data)
-      - [Binary Alignment Rules](#binary-alignment-rules)
-    - [Metadata Texture Encoding](#metadata-texture-encoding-1)
-      - [Numeric Textures](#numeric-textures)
-      - [Array Textures](#array-textures)
-      - [Implementation Notes](#implementation-notes)
-  - [Glossary](#glossary)
+- [Overview](#overview)
+- [Concepts](#concepts)
+  - [Classes](#classes)
+  - [Instances](#instances)
+    - [Instance Tables](#instance-tables)
+    - [JSON Encoding](#json-encoding)
+    - [Binary Encoding](#binary-encoding)
+    - [Metadata Texture Encoding](#metadata-texture-encoding)
+    - [Comparison of Encodings](#comparison-of-encodings)
+  - [Separate Class Definition from Instantiation](#separate-class-definition-from-instantiation)
+- [Class Definitions](#class-definitions)
+  - [Basic Types](#basic-types)
+  - [Normalized Properties](#normalized-properties)
+  - [Arrays](#arrays)
+  - [Optional and Default Properties](#optional-and-default-properties)
+- [Storage Encodings](#storage-encodings)
+  - [JSON Encoding](#json-encoding-1)
+    - [Basic Types](#basic-types-1)
+    - [Bit Depth of Numeric Types](#bit-depth-of-numeric-types)
+    - [Array Types](#array-types)
+    - [Fixed-length Strings and Blobs](#fixed-length-strings-and-blobs)
+    - [Optional and Default Values](#optional-and-default-values)
+    - [Single Instance Shorthand](#single-instance-shorthand)
+  - [Binary Encoding](#binary-encoding-1)
+    - [Numeric Types](#numeric-types)
+    - [Strings and Blobs](#strings-and-blobs)
+    - [Fixed-length Strings and Blobs](#fixed-length-strings-and-blobs-1)
+    - [Arrays](#arrays-1)
+    - [Variable-size Arrays](#variable-size-arrays)
+    - [Boolean Data](#boolean-data)
+    - [Binary Alignment Rules](#binary-alignment-rules)
+  - [Metadata Texture Encoding](#metadata-texture-encoding-1)
+    - [Numeric Textures](#numeric-textures)
+    - [Array Textures](#array-textures)
+    - [Implementation Notes](#implementation-notes)
+- [Glossary](#glossary)
 
-## Abstract
+## Overview
 
 This specification provides a standard format for adding metadata to Cesium 3D Tiles as well as glTF models. It provides a method for defining metadata, as well as methods for storing this metadata in JSON, binary, or texture encodings. This metadata format is shared by several Cesium specifications. This avoids repetition and enforces a consistent data layout. Specifications that reference this document must include at least one metadata encoding as described in this document, and must make clear which encodings are supported.
-
-## Introduction
 
 ```
 features = geometry + metadata
@@ -272,7 +269,7 @@ This is useful for continuous properties such as elevation, vegetation index, ve
 }
 ```
 
-**Note**: The method of selecting a texture is implementation-defined. The above example is based on a glTF implementation where `index` selects a texture and `texCoord` selects the texture coordinates. Other implementations may do select a texture by other means.
+The method of selecting a texture is implementation-defined. The above example is based on a glTF implementation where `index` selects a texture and `texCoord` selects the texture coordinates. Other implementations may do select a texture by other means.
 
 #### Comparison of Encodings
 
@@ -309,7 +306,7 @@ This specification keeps class definition separate from instantiation. While thi
 
 A class is a collection of properties. Each class requires a unique UTF-8 string as a class ID. This allows the classes to be referenced elsewhere in the JSON. Within the class, one or more properties is defined. Each property must have an ID that is unique within the class. Like the class IDs, this is a UTF-8 string. Each property has a type associated with it. Some types have extra options; the sections below discuss such cases.
 
-Also note that both classes and properties can be annotated with display names and descriptions, as in the following example:
+Both classes and properties can be annotated with display names and descriptions, as in the following example:
 
 ```json
 {
@@ -426,13 +423,13 @@ Example:
 }
 ```
 
-**Note**: optional properties are disallowed for the binary encoding in the interest of efficient runtime performance.
+Optional properties are disallowed for the binary encoding in the interest of efficient runtime performance.
 
 ## Storage Encodings
 
 The following sections provide a full description of each of the metadata encodings.
 
-**Note**: Each instance table must use the same encoding for all properties contained within. For example, if one property in an instance table is stored using binary encoding, then all other properties in this table must do likewise. If a mix of JSON and binary metadata is desired, this can be accomplished by using multiple instance tables.
+Each instance table must use the same encoding for all properties contained within. For example, if one property in an instance table is stored using binary encoding, then all other properties in this table must do likewise. If a mix of JSON and binary metadata is desired, this can be accomplished by using multiple instance tables.
 
 ### JSON Encoding
 
@@ -1053,7 +1050,7 @@ the _bit_ offsets, rather than the usual byte offsets. Again, the offsets are co
 
 Due to the possibility of 64-bit data types, this extension requires that each `bufferView` is aligned to a multiple of 8 bytes for efficient reads. This alignment requirement is always measured from the start of the binary file. This alignment requirement only applies to the start of each bufferView used for metadata.
 
-Note that to meet this alignment requirement, padding or other data must go between the `bufferView`s so that each starts on an 8-byte boundary.
+To meet this alignment requirement, padding or other data must go between the `bufferView`s so that each starts on an 8-byte boundary.
 
 ![Binary alignment diagram](figures/binary-alignment.png)
 
@@ -1101,7 +1098,7 @@ In the following example, a single-channel image is used to encode surface tempe
 }
 ```
 
-**Note**: in the above example, the `texture` object is based on a glTF implementation. See [Implementation Notes](#implementation-notes) below.
+In the above example, the `texture` object is based on a glTF implementation. See [Implementation Notes](#implementation-notes) below.
 
 #### Array Textures
 
@@ -1142,7 +1139,7 @@ The example below demonstrates representing a `vec3` using a 3-channel image. Th
 }
 ```
 
-**Note**: in the above example, the `texture` object is based on a glTF implementation. See [Implementation Notes](#implementation-notes) below.
+In the above example, the `texture` object is based on a glTF implementation. See [Implementation Notes](#implementation-notes) below.
 
 ![vec3 metadata texture](figures/vec3-texture.jpg)
 

--- a/specification/Metadata/0.0.0/schema/class.property.schema.json
+++ b/specification/Metadata/0.0.0/schema/class.property.schema.json
@@ -33,7 +33,7 @@
         "STRING",
         "ARRAY"
       ],
-      "description": "The type of each element of the property array. A `type` is either a basic type used for `componentType` or an `ARRAY`. If `ARRAY` is used, then `componentType` must also be specified. `ARRAY` is a fixed-length array when `componentCount` is defined, and variable-length otherwise. `BLOB` is variable-length unless `blobByteLength` is defined. `STRING` is variable-length unless `stringByteLength` is defined. In these cases, the blobs/strings must be exactly that many bytes. Variable-length arrays, `STRING`, and `BLOB` also require a corresponding `offsetBufferView`. This is used to indicate where each element starts in the buffer. See further notes about offset buffers in the description for `componentType`."
+      "description": "The type of each element of the property array. A `type` is either a basic type used for `componentType` or an `ARRAY`. If `ARRAY` is used, then `componentType` must also be specified. `ARRAY` is a fixed-length array when `componentCount` is defined, and variable-length otherwise. `BLOB` is variable-length unless `blobByteLength` is defined. `BLOB` is only allowed in binary encoding. `STRING` is variable-length unless `stringByteLength` is defined. In these cases, the blobs/strings must be exactly that many bytes. Variable-length arrays, `STRING`, and `BLOB` also require a corresponding `offsetBufferView`. This is used to indicate where each element starts in the buffer. See further notes about offset buffers in the description for `componentType`."
     },
     "componentType": {
       "enum": [
@@ -67,7 +67,7 @@
     "blobByteLength": {
       "type": "integer",
       "minimum": 1,
-      "description": "This property can only be used with a `BLOB` property or an `ARRAY` of `BLOB`. When present, all blob values for this property must be exactly this length in bytes. If the property is an `ARRAY`, then each component must have this byte length. Furthermore, no `offsetBufferView` is needed for specifying the start byte of each blob. In cases where the blob is Base64 encoded in JSON, `blobByteLength` describes the **decoded** byte length, not the Base64 string."
+      "description": "This property can only be used with a `BLOB` property or an `ARRAY` of `BLOB`. When present, all blob values for this property must be exactly this length in bytes. If the property is an `ARRAY`, then each component must have this byte length. Furthermore, no `offsetBufferView` is needed for specifying the start byte of each blob."
     },
     "normalized": {
       "type": "boolean",
@@ -92,7 +92,7 @@
     },
     "default": {
       "type": ["boolean", "number", "string", "array"],
-      "description": "A default value to use when this property is not defined or is set to `null`. If used, `optional` must be set to true. This property is only valid when using JSON encoding. The type of the value must match the property declaration (e.g. for a `STRING`, use a JSON string. For an integer or floating point value, use a JSON number). However, `BLOB` properties must be encoded in Base64 encoding since JSON does not support arbitrary binary sequences."
+      "description": "A default value to use when this property is not defined or is set to `null`. If used, `optional` must be set to true. This property is only valid when using JSON encoding. The type of the value must match the property declaration (e.g. for a `STRING`, use a JSON string. For an integer or floating point value, use a JSON number)."
     },
     "optional": {
       "type": "boolean",

--- a/specification/Metadata/0.0.0/schema/instanceTable.property.schema.json
+++ b/specification/Metadata/0.0.0/schema/instanceTable.property.schema.json
@@ -10,7 +10,7 @@
         "oneOf": [
           {
             "type": ["boolean", "number", "string", "null"],
-            "description": "Integer and floating point types are encoded as `number`. `BOOLEAN` is encoded as `boolean`. `STRING` is encoded as `string`. `BLOB` is encoded as a `string` using Base64 encoding. Null values are only allowed when the property is declared as `optional`"
+            "description": "Integer and floating point types are encoded as `number`. `BOOLEAN` is encoded as `boolean`. `STRING` is encoded as `string`. Null values are only allowed when the property is declared as `optional`"
           },
           {
             "type": "array",


### PR DESCRIPTION
This branch has my changes to the Cesium 3D Metadata Spec.

Changes so far:

- Addressed many small edits based on feedback
- Did a pass to update the glossary (though there's still some terms I think we need to define better)
- Started removing unnecessary forward references
- Started removing unnecessary sentences for conciseness
- Wrote text for a non-normative overview of how metadata is used in 3D Tiles at various levels of granularity
- Added an appendix to compare this metadata spec to the old batch tables concept 
- pointed out places where diagrams will go, as we need many more

@sanjeetsuhag @ErixenCruz 