### PR TITLE
Adds semantics for tile and content bounding volumes

### DIFF
--- a/extensions/3DTILES_metadata/1.0.0/README.md
+++ b/extensions/3DTILES_metadata/1.0.0/README.md
@@ -192,7 +192,7 @@ Note that the optional property `country` is omitted in the example below.
 
 ### Tile Metadata
 
-Metadata may be assigned to individual tiles. Tile metadata often contains spatial information to optimize traversal algorithms. The example below uses the built-in semantic `HORIZON_OCCLUSION_POINT` from the [Cesium Metadata Semantic Reference](../../../specification/Metadata/Semantics).
+Metadata may be assigned to individual tiles. Tile metadata often contains spatial information to optimize traversal algorithms. The example below uses the built-in semantic `TILE_HORIZON_OCCLUSION_POINT` from the [Cesium Metadata Semantic Reference](../../../specification/Metadata/Semantics).
 
 ```jsonc
 {
@@ -206,7 +206,7 @@ Metadata may be assigned to individual tiles. Tile metadata often contains spati
                 "type": "ARRAY",
                 "componentType": "FLOAT64",
                 "componentCount": 4,
-                "semantic": "HORIZON_OCCLUSION_POINT",
+                "semantic": "TILE_HORIZON_OCCLUSION_POINT",
               },
               "countries": {
                 "description": "The countries that this tile overlaps",

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -56,7 +56,7 @@ The bounding volume of the tile, expressed as a [sphere (as defined by 3D Tiles 
 <!-- omit in toc -->
 ### **CONTENT_BOUNDING_BOX**
 
-The bounding volume of the content of a tile, expressed as a [box (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#box). This property may be used to describe a tighter bounding volume for the content of a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). The content bounding volume must be completely contained within the bounding volume of a tile.
+The bounding volume of the content of a tile, expressed as a [box (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#box). This property may be used to describe a tighter bounding volume for the content of a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). This property is equivalent to `tile.content.boundingVolume.box`.
 
 * Type: `ARRAY`
 * Component type: `FLOAT32` or `FLOAT64`
@@ -65,7 +65,7 @@ The bounding volume of the content of a tile, expressed as a [box (as defined by
 <!-- omit in toc -->
 ### **CONTENT_BOUNDING_REGION**
 
-The bounding volume of the content of a tile, expressed as a [region (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#region). This property may be used to describe a tighter bounding volume for the content of a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). The content bounding volume must be completely contained within the bounding volume of a tile.
+The bounding volume of the content of a tile, expressed as a [region (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#region). This property may be used to describe a tighter bounding volume for the content of a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). This property is equivalent to `tile.content.boundingVolume.region`.
 
 * Type: `ARRAY`
 * Component type: `FLOAT64`
@@ -74,7 +74,7 @@ The bounding volume of the content of a tile, expressed as a [region (as defined
 <!-- omit in toc -->
 ### **CONTENT_BOUNDING_SPHERE**
 
-The bounding volume of the content of  tile, expressed as a [sphere (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#sphere). The content bounding volume must be completely contained within the bounding volume of a tile.
+The bounding volume of the content of  tile, expressed as a [sphere (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#sphere). This property is equivalent to `tile.content.boundingVolume.sphere`.
 
 * Type: `ARRAY`
 * Component type: `FLOAT32` or `FLOAT64`

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -27,6 +27,42 @@ For full usage see:
 * [`EXT_feature_metadata`](https://github.com/CesiumGS/glTF/tree/master/extensions/2.0/Vendor/EXT_feature_metadata/1.0.0) - glTF extension that assigns metadata to features in a model on a per-vertex, per-texel, or per-instance basis
 
 <!-- omit in toc -->
+### **TILE_BOUNDING_BOX**
+
+The bounding volume of the tile, expressed as a box (as defined by 3D Tiles 1.0). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md).
+
+* Type: `ARRAY`
+* Component type: `FLOAT64`
+* Component count: `12`
+
+<!-- omit in toc -->
+### **TILE_BOUNDING_REGION**
+
+The bounding volume of the tile, expressed as a region (as defined by 3D Tiles 1.0). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md).
+
+* Type: `ARRAY`
+* Component type: `FLOAT64`
+* Component count: `6`
+
+<!-- omit in toc -->
+### **CONTENT_BOUNDING_BOX**
+
+The bounding volume of the content of a tile, expressed as a box (as defined by 3D Tiles 1.0). This property may be used to describe a tighter bounding volume for the content of a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). The content bounding volume must be completely contained within the bounding volume of a tile.
+
+* Type: `ARRAY`
+* Component type: `FLOAT64`
+* Component count: `12`
+
+<!-- omit in toc -->
+### **CONTENT_BOUNDING_REGION**
+
+The bounding volume of the content of a tile, expressed as a region (as defined by 3D Tiles 1.0). This property may be used to describe a tighter bounding volume for the content of a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). The content bounding volume must be completely contained within the bounding volume of a tile.
+
+* Type: `ARRAY`
+* Component type: `FLOAT64`
+* Component count: `6`
+
+<!-- omit in toc -->
 ### **HORIZON_OCCLUSION_POINT**
 
 The horizon occlusion point expressed in an ellipsoid-scaled fixed frame. If this point is below the horizon, the entire entity is below the horizon. See [Horizon Culling](https://cesium.com/blog/2013/04/25/horizon-culling/) for more information. This semantic is often used with tile metadata.

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -81,25 +81,25 @@ The bounding volume of the content of  tile, expressed as a [sphere (as defined 
 * Component count: `4`
 
 <!-- omit in toc -->
-### **HORIZON_OCCLUSION_POINT**
+### **TILE_HORIZON_OCCLUSION_POINT**
 
-The horizon occlusion point expressed in an ellipsoid-scaled fixed frame. If this point is below the horizon, the entire entity is below the horizon. See [Horizon Culling](https://cesium.com/blog/2013/04/25/horizon-culling/) for more information. This semantic is often used with tile metadata.
+The horizon occlusion point of the tile expressed in an ellipsoid-scaled fixed frame. If this point is below the horizon, the entire entity is below the horizon. See [Horizon Culling](https://cesium.com/blog/2013/04/25/horizon-culling/) for more information. This semantic is often used with tile metadata.
 
 * Type: `ARRAY`
 * Component type: `FLOAT32` or `FLOAT64`
 * Component count: `3`
 
 <!-- omit in toc -->
-### **MINIMUM_HEIGHT**
+### **TILE_MINIMUM_HEIGHT**
 
-The minimum height relative to some ellipsoid.
+The minimum height of the tile above (or below) the WGS84 ellipsoid. When a tile bounding volume is explicitly defined for a tile, this property will be be ignored.
 
 * Type: `FLOAT32` or `FLOAT64`
 
 <!-- omit in toc -->
-### **MAXIMUM_HEIGHT**
+### **TILE_MAXIMUM_HEIGHT**
 
-The maximum height relative to some ellipsoid.
+The maximum height of the tile above (or below) the WGS84 ellipsoid. When a tile bounding volume is explicitly defined for a tile, this property will be be ignored.
 
 * Type: `FLOAT32` or `FLOAT64`
 

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -104,15 +104,6 @@ The maximum height of the tile above (or below) the WGS84 ellipsoid. When a tile
 * Type: `FLOAT32` or `FLOAT64`
 
 <!-- omit in toc -->
-### **BOUNDING_SPHERE**
-
-A bounding sphere as `[x, y, z, radius]`.
-
-* Type: `ARRAY`
-* Component type: `FLOAT32` or `FLOAT64`
-* Component count: `4`
-
-<!-- omit in toc -->
 ### **NAME**
 
 The name of the entity. Names do not have to be unique.

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -29,7 +29,7 @@ For full usage see:
 <!-- omit in toc -->
 ### **TILE_BOUNDING_BOX**
 
-The bounding volume of the tile, expressed as a [box (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#box). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md).
+The bounding volume of the tile, expressed as a [box (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#box). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). This property is equivalent to `tile.boundingVolume.box`.
 
 * Type: `ARRAY`
 * Component type: `FLOAT32` or `FLOAT64`
@@ -38,7 +38,7 @@ The bounding volume of the tile, expressed as a [box (as defined by 3D Tiles 1.0
 <!-- omit in toc -->
 ### **TILE_BOUNDING_REGION**
 
-The bounding volume of the tile, expressed as a [region (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#region). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md).
+The bounding volume of the tile, expressed as a [region (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#region). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). This property is equivalent to `tile.boundingVolume.region`.
 
 * Type: `ARRAY`
 * Component type: `FLOAT64`
@@ -47,13 +47,13 @@ The bounding volume of the tile, expressed as a [region (as defined by 3D Tiles 
 <!-- omit in toc -->
 ### **TILE_BOUNDING_SPHERE**
 
-The bounding volume of the tile, expressed as a [sphere (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#sphere).
+The bounding volume of the tile, expressed as a [sphere (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#sphere). This property is equivalent to `tile.boundingVolume.sphere`.
 
 * Type: `ARRAY`
 * Component type: `FLOAT32` or `FLOAT64`
 * Component count: `4`
 
-*Note: Only one type of tile bounding volume may be specified at a time.*
+> **Implementation Note**: If multiple tile bounding volumes are specified the implementation may decide which bounding volume to use.
 
 <!-- omit in toc -->
 ### **CONTENT_BOUNDING_BOX**
@@ -82,48 +82,59 @@ The bounding volume of the content of  tile, expressed as a [sphere (as defined 
 * Component type: `FLOAT32` or `FLOAT64`
 * Component count: `4`
 
-*Note: Only one type of content bounding volume may be specified at a time.*
-
-<!-- omit in toc -->
-### **TILE_HORIZON_OCCLUSION_POINT**
-
-The horizon occlusion point of the tile expressed in an ellipsoid-scaled fixed frame. If this point is below the horizon, the entire entity is below the horizon. See [Horizon Culling](https://cesium.com/blog/2013/04/25/horizon-culling/) for more information. This semantic is often used with tile metadata.
-
-* Type: `ARRAY`
-* Component type: `FLOAT32` or `FLOAT64`
-* Component count: `3`
+> **Implementation Note**: If multiple content bounding volumes are specified the implementation may decide which bounding volume to use.
 
 <!-- omit in toc -->
 ### **TILE_MINIMUM_HEIGHT**
 
-The minimum height of the tile above (or below) the WGS84 ellipsoid. When a tile bounding volume is explicitly defined for a tile, this property will be be ignored.
+The minimum height of the tile above (or below) the WGS84 ellipsoid.
 
 * Type: `FLOAT32` or `FLOAT64`
 
 <!-- omit in toc -->
 ### **TILE_MAXIMUM_HEIGHT**
 
-The maximum height of the tile above (or below) the WGS84 ellipsoid. When a tile bounding volume is explicitly defined for a tile, this property will be be ignored.
+The maximum height of the tile above (or below) the WGS84 ellipsoid.
 
 * Type: `FLOAT32` or `FLOAT64`
 
-> **Implementation Note**: If `TILE_BOUNDING_REGION` is specified along with a `TILE_MAXIMIUM_HEIGHT` or `TILE_MINIMUM_HEIGHT`, the heights will be ignored.
+> **Implementation Note**: `TILE_MINIMUM_HEIGHT` and `TILE_MAXIMUM_HEIGHT` may be ignored if `TILE_BOUNDING_REGION` is specified or if the tile has an explicit bounding volume.
 
 <!-- omit in toc -->
 ### **CONTENT_MINIMUM_HEIGHT**
 
-The minimum height of the content of a tile above (or below) the WGS84 ellipsoid. When a content bounding volume is explicitly defined for a tile, this property will be be ignored.
+The minimum height of the content of a tile above (or below) the WGS84 ellipsoid.
 
 * Type: `FLOAT32` or `FLOAT64`
 
 <!-- omit in toc -->
 ### **CONTENT_MAXIMUM_HEIGHT**
 
-The maximum height of the content of a tile above (or below) the WGS84 ellipsoid. When a content bounding volume is explicitly defined for a tile, this property will be be ignored.
+The maximum height of the content of a tile above (or below) the WGS84 ellipsoid.
 
 * Type: `FLOAT32` or `FLOAT64`
 
-> **Implementation Note**: If `CONTENT_BOUNDING_REGION` is specified along with a `CONTENT_MAXIMIUM_HEIGHT` or `CONTENT_MINIMUM_HEIGHT`, the heights will be ignored.
+> **Implementation Note**: `CONTENT_MINIMUM_HEIGHT` and `CONTENT_MAXIMUM_HEIGHT` may be ignored if `CONTENT_BOUNDING_REGION` is specified or if the tile has an explicit content bounding volume.
+
+<!-- omit in toc -->
+### **TILE_HORIZON_OCCLUSION_POINT**
+
+The horizon occlusion point of the tile expressed in an ellipsoid-scaled fixed frame. If this point is below the horizon, the entire tile is below the horizon. See [Horizon Culling](https://cesium.com/blog/2013/04/25/horizon-culling/) for more information.
+
+* Type: `ARRAY`
+* Component type: `FLOAT32` or `FLOAT64`
+* Component count: `3`
+
+<!-- omit in toc -->
+### **CONTENT_HORIZON_OCCLUSION_POINT**
+
+The horizon occlusion point of the content of a tile expressed in an ellipsoid-scaled fixed frame. If this point is below the horizon, the entire content is below the horizon. See [Horizon Culling](https://cesium.com/blog/2013/04/25/horizon-culling/) for more information.
+
+* Type: `ARRAY`
+* Component type: `FLOAT32` or `FLOAT64`
+* Component count: `3`
+
+> **Implementation Note**: Just as tile bounding volumes provide spatial coherence for traversal while content bounding volumes enable finer grained culling, the computation of `TILE_HORIZON_OCCLUSION_POINT` should account for all content in a tile and its descendants whereas `CONTENT_HORIZON_OCCLUSION_POINT` should only account for content in a tile. When the two values are equivalent only `TILE_HORIZON_OCCLUSION_POINT` should be specified.
 
 <!-- omit in toc -->
 ### **NAME**

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -80,7 +80,6 @@ The bounding volume of the content of  tile, expressed as a [sphere (as defined 
 * Component type: `FLOAT32` or `FLOAT64`
 * Component count: `4`
 
-
 <!-- omit in toc -->
 ### **HORIZON_OCCLUSION_POINT**
 

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -81,7 +81,7 @@ The bounding volume of the content of  tile, expressed as a [sphere (as defined 
 * Component count: `4`
 
 <!-- omit in toc -->
-### **TILE_TILE_HORIZON_OCCLUSION_POINT**
+### **TILE_HORIZON_OCCLUSION_POINT**
 
 The horizon occlusion point of the tile expressed in an ellipsoid-scaled fixed frame. If this point is below the horizon, the entire entity is below the horizon. See [Horizon Culling](https://cesium.com/blog/2013/04/25/horizon-culling/) for more information. This semantic is often used with tile metadata.
 

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -110,6 +110,22 @@ The maximum height of the tile above (or below) the WGS84 ellipsoid. When a tile
 > **Implementation Note**: If `TILE_BOUNDING_REGION` is specified along with a `TILE_MAXIMIUM_HEIGHT` or `TILE_MINIMUM_HEIGHT`, the heights will be ignored.
 
 <!-- omit in toc -->
+### **CONTENT_MINIMUM_HEIGHT**
+
+The minimum height of the content of a tile above (or below) the WGS84 ellipsoid. When a content bounding volume is explicitly defined for a tile, this property will be be ignored.
+
+* Type: `FLOAT32` or `FLOAT64`
+
+<!-- omit in toc -->
+### **CONTENT_MAXIMUM_HEIGHT**
+
+The maximum height of the content of a tile above (or below) the WGS84 ellipsoid. When a content bounding volume is explicitly defined for a tile, this property will be be ignored.
+
+* Type: `FLOAT32` or `FLOAT64`
+
+> **Implementation Note**: If `CONTENT_BOUNDING_REGION` is specified along with a `CONTENT_MAXIMIUM_HEIGHT` or `CONTENT_MINIMUM_HEIGHT`, the heights will be ignored.
+
+<!-- omit in toc -->
 ### **NAME**
 
 The name of the entity. Names do not have to be unique.

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -47,7 +47,7 @@ The bounding volume of the tile, expressed as a [region (as defined by 3D Tiles 
 <!-- omit in toc -->
 ### **TILE_BOUNDING_SPHERE**
 
-The bounding volume of the tile, expressed as a [sphere (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#sphere). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md).
+The bounding volume of the tile, expressed as a [sphere (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#sphere).
 
 * Type: `ARRAY`
 * Component type: `FLOAT32` or `FLOAT64`
@@ -74,7 +74,7 @@ The bounding volume of the content of a tile, expressed as a [region (as defined
 <!-- omit in toc -->
 ### **CONTENT_BOUNDING_SPHERE**
 
-The bounding volume of the content of  tile, expressed as a [sphere (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#sphere). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). The content bounding volume must be completely contained within the bounding volume of a tile.
+The bounding volume of the content of  tile, expressed as a [sphere (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#sphere). The content bounding volume must be completely contained within the bounding volume of a tile.
 
 * Type: `ARRAY`
 * Component type: `FLOAT32` or `FLOAT64`

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -2,7 +2,7 @@
 
 This document defines a general set of semantics for 3D Tiles and glTF. Tileset authors may define their own application- or domain-specific semantics separately.
 
-Semantics describe how properties should be interpreted. For example, an application that sees the `HORIZON_OCCLUSION_POINT` semantic would use the property for horizon occlusion culling as defined below.
+Semantics describe how properties should be interpreted. For example, an application that sees the `TILE_HORIZON_OCCLUSION_POINT` semantic would use the property for horizon occlusion culling as defined below.
 
 ```jsonc
 {
@@ -11,7 +11,7 @@ Semantics describe how properties should be interpreted. For example, an applica
       "type": "ARRAY",
       "componentType": "FLOAT64",
       "componentCount": 4,
-      "semantic": "HORIZON_OCCLUSION_POINT",
+      "semantic": "TILE_HORIZON_OCCLUSION_POINT",
     },
     "name": {
       "type": "STRING",
@@ -81,7 +81,7 @@ The bounding volume of the content of  tile, expressed as a [sphere (as defined 
 * Component count: `4`
 
 <!-- omit in toc -->
-### **TILE_HORIZON_OCCLUSION_POINT**
+### **TILE_TILE_HORIZON_OCCLUSION_POINT**
 
 The horizon occlusion point of the tile expressed in an ellipsoid-scaled fixed frame. If this point is below the horizon, the entire entity is below the horizon. See [Horizon Culling](https://cesium.com/blog/2013/04/25/horizon-culling/) for more information. This semantic is often used with tile metadata.
 

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -29,38 +29,57 @@ For full usage see:
 <!-- omit in toc -->
 ### **TILE_BOUNDING_BOX**
 
-The bounding volume of the tile, expressed as a box (as defined by 3D Tiles 1.0). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md).
+The bounding volume of the tile, expressed as a [box (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#box). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md).
 
 * Type: `ARRAY`
-* Component type: `FLOAT64`
+* Component type: `FLOAT32` or `FLOAT64`
 * Component count: `12`
 
 <!-- omit in toc -->
 ### **TILE_BOUNDING_REGION**
 
-The bounding volume of the tile, expressed as a region (as defined by 3D Tiles 1.0). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md).
+The bounding volume of the tile, expressed as a [region (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#region). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md).
 
 * Type: `ARRAY`
-* Component type: `FLOAT64`
+* Component type: `FLOAT32` or `FLOAT64`
 * Component count: `6`
+
+<!-- omit in toc -->
+### **TILE_BOUNDING_SPHERE**
+
+The bounding volume of the tile, expressed as a [sphere (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#sphere). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md).
+
+* Type: `ARRAY`
+* Component type: `FLOAT32` or `FLOAT64`
+* Component count: `4`
 
 <!-- omit in toc -->
 ### **CONTENT_BOUNDING_BOX**
 
-The bounding volume of the content of a tile, expressed as a box (as defined by 3D Tiles 1.0). This property may be used to describe a tighter bounding volume for the content of a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). The content bounding volume must be completely contained within the bounding volume of a tile.
+The bounding volume of the content of a tile, expressed as a [box (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#box). This property may be used to describe a tighter bounding volume for the content of a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). The content bounding volume must be completely contained within the bounding volume of a tile.
 
 * Type: `ARRAY`
-* Component type: `FLOAT64`
+* Component type: `FLOAT32` or `FLOAT64`
 * Component count: `12`
 
 <!-- omit in toc -->
 ### **CONTENT_BOUNDING_REGION**
 
-The bounding volume of the content of a tile, expressed as a region (as defined by 3D Tiles 1.0). This property may be used to describe a tighter bounding volume for the content of a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). The content bounding volume must be completely contained within the bounding volume of a tile.
+The bounding volume of the content of a tile, expressed as a [region (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#region). This property may be used to describe a tighter bounding volume for the content of a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). The content bounding volume must be completely contained within the bounding volume of a tile.
 
 * Type: `ARRAY`
-* Component type: `FLOAT64`
+* Component type: `FLOAT32` or `FLOAT64`
 * Component count: `6`
+
+<!-- omit in toc -->
+### **CONTENT_BOUNDING_SPHERE**
+
+The bounding volume of the content of  tile, expressed as a [sphere (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#sphere). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). The content bounding volume must be completely contained within the bounding volume of a tile.
+
+* Type: `ARRAY`
+* Component type: `FLOAT32` or `FLOAT64`
+* Component count: `4`
+
 
 <!-- omit in toc -->
 ### **HORIZON_OCCLUSION_POINT**

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -41,7 +41,7 @@ The bounding volume of the tile, expressed as a [box (as defined by 3D Tiles 1.0
 The bounding volume of the tile, expressed as a [region (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#region). This property may be used to describe a tighter bounding volume for a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md).
 
 * Type: `ARRAY`
-* Component type: `FLOAT32` or `FLOAT64`
+* Component type: `FLOAT64`
 * Component count: `6`
 
 <!-- omit in toc -->
@@ -68,7 +68,7 @@ The bounding volume of the content of a tile, expressed as a [box (as defined by
 The bounding volume of the content of a tile, expressed as a [region (as defined by 3D Tiles 1.0)](https://github.com/CesiumGS/3d-tiles/tree/master/specification#region). This property may be used to describe a tighter bounding volume for the content of a tile than is implicitly calculated by [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/blob/3d-tiles-next/extensions/3DTILES_implicit_tiling/0.0.0/README.md). The content bounding volume must be completely contained within the bounding volume of a tile.
 
 * Type: `ARRAY`
-* Component type: `FLOAT32` or `FLOAT64`
+* Component type: `FLOAT64`
 * Component count: `6`
 
 <!-- omit in toc -->

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -53,6 +53,8 @@ The bounding volume of the tile, expressed as a [sphere (as defined by 3D Tiles 
 * Component type: `FLOAT32` or `FLOAT64`
 * Component count: `4`
 
+*Note: Only one type of tile bounding volume may be specified at a time.*
+
 <!-- omit in toc -->
 ### **CONTENT_BOUNDING_BOX**
 
@@ -80,6 +82,8 @@ The bounding volume of the content of  tile, expressed as a [sphere (as defined 
 * Component type: `FLOAT32` or `FLOAT64`
 * Component count: `4`
 
+*Note: Only one type of content bounding volume may be specified at a time.*
+
 <!-- omit in toc -->
 ### **TILE_HORIZON_OCCLUSION_POINT**
 
@@ -102,6 +106,8 @@ The minimum height of the tile above (or below) the WGS84 ellipsoid. When a tile
 The maximum height of the tile above (or below) the WGS84 ellipsoid. When a tile bounding volume is explicitly defined for a tile, this property will be be ignored.
 
 * Type: `FLOAT32` or `FLOAT64`
+
+> **Implementation Note**: If `TILE_BOUNDING_REGION` is specified along with a `TILE_MAXIMIUM_HEIGHT` or `TILE_MINIMUM_HEIGHT`, the heights will be ignored.
 
 <!-- omit in toc -->
 ### **NAME**


### PR DESCRIPTION
The following semantics allow `3DTILES_metadata` to specify information about the bounding volume of a tile or a tile's content:

- `TILE_BOUNDING_BOX`
- `TILE_BOUNDING_REGION`
- `TILE_BOUNDING_SPHERE`
- `CONTENT_BOUNDING_BOX`
- `CONTENT_BOUNDING_REGION`
- `CONTENT_BOUNDING_SPHERE`