### PR TITLE
Changed type of component type to string

### DIFF
--- a/specification/schema/featureTable.schema.json
+++ b/specification/schema/featureTable.schema.json
@@ -16,7 +16,7 @@
                     "minimum" : 0
                 },
                 "componentType" : {
-                    "type" : "number",
+                    "type" : "string",
                     "description": "The datatype of components in the property. This is defined only if the semantic allows for overriding the implicit component type. These cases are specified in each tile format.",
                     "enum" : ["BYTE", "UNSIGNED_BYTE", "SHORT", "UNSIGNED_SHORT", "INT", "UNSIGNED_INT", "FLOAT", "DOUBLE"]
                 }


### PR DESCRIPTION
The type of the componentType of the binaryBodyReference of the feature table was declared as number, but should be a string.

Fixes https://github.com/CesiumGS/3d-tiles/issues/467
