### PR TITLE
Explicitly set type of tileset.properties

### DIFF
--- a/specification/schema/tileset.schema.json
+++ b/specification/schema/tileset.schema.json
@@ -9,6 +9,7 @@
             "$ref" : "asset.schema.json"
         },
         "properties" : {
+            "type": "object",
             "description": "A dictionary object of metadata about per-feature properties.",
             "properties" : {},
             "additionalProperties" : {


### PR DESCRIPTION
`tileset.properties` is implicitly an `object` due to `additionalProperties`, making it explicit