### PR TITLE
Change number to integer for other areas of the spec

### DIFF
--- a/extensions/3DTILES_batch_table_hierarchy/schema/3DTILES_batch_table_hierarchy.json
+++ b/extensions/3DTILES_batch_table_hierarchy/schema/3DTILES_batch_table_hierarchy.json
@@ -12,7 +12,7 @@
                         "type" : "string"
                     },
                     "length" : {
-                        "type" : "number",
+                        "type" : "integer",
                         "minimum" : 0
                     },
                     "instances" : {
@@ -26,7 +26,7 @@
             }
         },
         "instancesLength" : {
-            "type" : "number",
+            "type" : "integer",
             "minimum" : 0
         },
         "classIds" : {
@@ -73,7 +73,7 @@
         "integerArray" : {
             "type" : "array",
             "items" : {
-                "type" : "number",
+                "type" : "integer",
                 "minimum" : 0
             }
         },

--- a/extensions/3DTILES_draco_point_compression/schema/3DTILES_draco_point_compression.batchTable.schema.json
+++ b/extensions/3DTILES_draco_point_compression/schema/3DTILES_draco_point_compression.batchTable.schema.json
@@ -10,7 +10,7 @@
             "description": "Defines the properties stored in the compressed data. Each property is associated with a unique ID. This ID is used to identify the property within the compressed data. No two properties in the Feature Table and Batch Table may use the same ID.",
             "minProperties": 1,
             "additionalProperties": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0
             }
         }

--- a/extensions/3DTILES_draco_point_compression/schema/3DTILES_draco_point_compression.featureTable.schema.json
+++ b/extensions/3DTILES_draco_point_compression/schema/3DTILES_draco_point_compression.featureTable.schema.json
@@ -10,17 +10,17 @@
             "description": "Defines the properties stored in the compressed data. Each property is associated with a unique ID. This ID is used to identify the property within the compressed data. No two properties in the Feature Table and Batch Table may use the same ID.",
             "minProperties": 1,
             "additionalProperties": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0
             }
         },
         "byteOffset": {
-            "type": "number",
+            "type": "integer",
             "description": "A zero-based offset relative to the start of the Feature Table binary at which the compressed data starts.",
             "minimum": 0
         },
         "byteLength": {
-            "type": "number",
+            "type": "integer",
             "description": "The length, in bytes, of the compressed data.",
             "minimum": 0
         }

--- a/specification/schema/batchTable.schema.json
+++ b/specification/schema/batchTable.schema.json
@@ -22,7 +22,7 @@
             "description" : "An object defining the reference to a section of the binary body of the batch table where the property values are stored if not defined directly in the JSON.",
             "properties" : {
                 "byteOffset" : {
-                    "type" : "number",
+                    "type" : "integer",
                     "description": "The offset into the buffer in bytes.",
                     "minimum" : 0
                 },


### PR DESCRIPTION
Follow up to https://github.com/CesiumGS/3d-tiles/pull/476 that changes `number` -> `integer` in other places of the spec.

Will follow up with a PR for [3d-tiles-next](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next).