### PR TITLE
add and use GlobalPropertyInteger for feature table lengths

### DIFF
--- a/specification/TileFormats/Batched3DModel/README.md
+++ b/specification/TileFormats/Batched3DModel/README.md
@@ -160,7 +160,7 @@ in the CesiumJS implementation of 3D Tiles.
 * [`Batched 3D Model Feature Table`](#reference-batched-3d-model-feature-table)
     * [`BinaryBodyReference`](#reference-binarybodyreference)
     * [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3)
-    * [`GlobalPropertyScalar`](#reference-globalpropertyscalar)
+    * [`GlobalPropertyInteger`](#reference-globalpropertyinteger)
     * [`Property`](#reference-property)
 
 
@@ -176,7 +176,7 @@ A set of Batched 3D Model semantics that contain additional information about fe
 |---|----|-----------|--------|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
-|**BATCH_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyScalar`](#reference-globalpropertyscalar) object defining a numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).| :white_check_mark: Yes|
+|**BATCH_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).| :white_check_mark: Yes|
 |**RTC_CENTER**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).|No|
 
 Additional properties are allowed.
@@ -199,7 +199,7 @@ Application-specific data.
 
 #### Batched3DModelFeatureTable.BATCH_LENGTH :white_check_mark:
 
-A [`GlobalPropertyScalar`](#reference-globalpropertyscalar) object defining a numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).
+A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).
 
 * **Type**: `object`, `number` `[1]`, `number`
 * **Required**: Yes
@@ -249,10 +249,10 @@ An object defining a global 3-component numeric property value for all features.
 
 
 ---------------------------------------
-<a name="reference-globalpropertyscalar"></a>
-### GlobalPropertyScalar
+<a name="reference-globalpropertyinteger"></a>
+### GlobalPropertyInteger
 
-An object defining a global numeric property value for all features.
+An object defining a global integer property value for all features.
 
 * **JSON schema**: [`featureTable.schema.json`](../../schema/featureTable.schema.json)
 

--- a/specification/TileFormats/Batched3DModel/README.md
+++ b/specification/TileFormats/Batched3DModel/README.md
@@ -176,7 +176,7 @@ A set of Batched 3D Model semantics that contain additional information about fe
 |---|----|-----------|--------|
 |**extensions**|`object`|Dictionary object with extension-specific objects.|No|
 |**extras**|`any`|Application-specific data.|No|
-|**BATCH_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).| :white_check_mark: Yes|
+|**BATCH_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).| :white_check_mark: Yes|
 |**RTC_CENTER**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).|No|
 
 Additional properties are allowed.
@@ -199,7 +199,7 @@ Application-specific data.
 
 #### Batched3DModelFeatureTable.BATCH_LENGTH :white_check_mark:
 
-A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).
+A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).
 
 * **Type**: `object`, `number` `[1]`, `number`
 * **Required**: Yes

--- a/specification/TileFormats/Instanced3DModel/README.md
+++ b/specification/TileFormats/Instanced3DModel/README.md
@@ -269,7 +269,7 @@ An explicit file extension is optional. Valid implementations may ignore it and 
 * [`Instanced 3D Model Feature Table`](#reference-instanced-3d-model-feature-table)
     * [`BinaryBodyReference`](#reference-binarybodyreference)
     * [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3)
-    * [`GlobalPropertyScalar`](#reference-globalpropertyscalar)
+    * [`GlobalPropertyInteger`](#reference-globalpropertyinteger)
     * [`Property`](#reference-property)
 
 
@@ -294,7 +294,7 @@ A set of Instanced 3D Model semantics that contains values defining the position
 |**SCALE**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
 |**SCALE_NON_UNIFORM**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
 |**BATCH_ID**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
-|**INSTANCES_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyScalar`](#reference-globalpropertyscalar) object defining a numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).| :white_check_mark: Yes|
+|**INSTANCES_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).| :white_check_mark: Yes|
 |**RTC_CENTER**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
 |**QUANTIZED_VOLUME_OFFSET**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
 |**QUANTIZED_VOLUME_SCALE**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
@@ -383,7 +383,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 
 #### Instanced3DModelFeatureTable.INSTANCES_LENGTH :white_check_mark:
 
-A [`GlobalPropertyScalar`](#reference-globalpropertyscalar) object defining a numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).
+A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).
 
 * **Type**: `object`, `number` `[1]`, `number`
 * **Required**: Yes
@@ -447,10 +447,10 @@ An object defining a global 3-component numeric property value for all features.
 * **JSON schema**: [`featureTable.schema.json`](../../schema/featureTable.schema.json)
 
 ---------------------------------------
-<a name="reference-globalpropertyscalar"></a>
-### GlobalPropertyScalar
+<a name="reference-globalpropertyinteger"></a>
+### GlobalPropertyInteger
 
-An object defining a global numeric property value for all features.
+An object defining a global integer property value for all features.
 
 * **JSON schema**: [`featureTable.schema.json`](../../schema/featureTable.schema.json)
 

--- a/specification/TileFormats/Instanced3DModel/README.md
+++ b/specification/TileFormats/Instanced3DModel/README.md
@@ -294,7 +294,7 @@ A set of Instanced 3D Model semantics that contains values defining the position
 |**SCALE**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
 |**SCALE_NON_UNIFORM**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
 |**BATCH_ID**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
-|**INSTANCES_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).| :white_check_mark: Yes|
+|**INSTANCES_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).| :white_check_mark: Yes|
 |**RTC_CENTER**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
 |**QUANTIZED_VOLUME_OFFSET**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
 |**QUANTIZED_VOLUME_SCALE**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).|No|
@@ -383,7 +383,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 
 #### Instanced3DModelFeatureTable.INSTANCES_LENGTH :white_check_mark:
 
-A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).
+A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).
 
 * **Type**: `object`, `number` `[1]`, `number`
 * **Required**: Yes

--- a/specification/TileFormats/PointCloud/README.md
+++ b/specification/TileFormats/PointCloud/README.md
@@ -375,12 +375,12 @@ A set of Point Cloud semantics that contains values defining the position and ap
 |**NORMAL**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 |**NORMAL_OCT16P**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 |**BATCH_ID**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
-|**POINTS_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).| :white_check_mark: Yes|
+|**POINTS_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).| :white_check_mark: Yes|
 |**RTC_CENTER**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 |**QUANTIZED_VOLUME_OFFSET**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 |**QUANTIZED_VOLUME_SCALE**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 |**CONSTANT_RGBA**|`object`, `number` `[4]`|A [`GlobalPropertyCartesian4`](#reference-globalpropertycartesian4) object defining a 4-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
-|**BATCH_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
+|**BATCH_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 
 Additional properties are allowed.
 
@@ -458,7 +458,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 
 #### PointCloudFeatureTable.POINTS_LENGTH :white_check_mark:
 
-A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
+A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
 
 * **Type**: `object`, `number` `[1]`, `number`
 * **Required**: Yes
@@ -493,7 +493,7 @@ A [`GlobalPropertyCartesian4`](#reference-globalpropertycartesian4) object defin
 
 #### PointCloudFeatureTable.BATCH_LENGTH
 
-A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
+A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
 
 * **Type**: `object`, `number` `[1]`, `number`
 * **Required**: No

--- a/specification/TileFormats/PointCloud/README.md
+++ b/specification/TileFormats/PointCloud/README.md
@@ -351,7 +351,7 @@ Code for reading the header can be found in [`PointCloud3DModelTileContent.js`](
     * [`BinaryBodyReference`](#reference-binarybodyreference)
     * [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3)
     * [`GlobalPropertyCartesian4`](#reference-globalpropertycartesian4)
-    * [`GlobalPropertyScalar`](#reference-globalpropertyscalar)
+    * [`GlobalPropertyInteger`](#reference-globalpropertyinteger)
     * [`Property`](#reference-property)
 
 
@@ -375,12 +375,12 @@ A set of Point Cloud semantics that contains values defining the position and ap
 |**NORMAL**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 |**NORMAL_OCT16P**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 |**BATCH_ID**|`object`|A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
-|**POINTS_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyScalar`](#reference-globalpropertyscalar) object defining a numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).| :white_check_mark: Yes|
+|**POINTS_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).| :white_check_mark: Yes|
 |**RTC_CENTER**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 |**QUANTIZED_VOLUME_OFFSET**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 |**QUANTIZED_VOLUME_SCALE**|`object`, `number` `[3]`|A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 |**CONSTANT_RGBA**|`object`, `number` `[4]`|A [`GlobalPropertyCartesian4`](#reference-globalpropertycartesian4) object defining a 4-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
-|**BATCH_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyScalar`](#reference-globalpropertyscalar) object defining a numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
+|**BATCH_LENGTH**|`object`, `number` `[1]`, `number`|A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).|No|
 
 Additional properties are allowed.
 
@@ -458,7 +458,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 
 #### PointCloudFeatureTable.POINTS_LENGTH :white_check_mark:
 
-A [`GlobalPropertyScalar`](#reference-globalpropertyscalar) object defining a numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
+A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
 
 * **Type**: `object`, `number` `[1]`, `number`
 * **Required**: Yes
@@ -493,7 +493,7 @@ A [`GlobalPropertyCartesian4`](#reference-globalpropertycartesian4) object defin
 
 #### PointCloudFeatureTable.BATCH_LENGTH
 
-A [`GlobalPropertyScalar`](#reference-globalpropertyscalar) object defining a numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
+A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining a integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
 
 * **Type**: `object`, `number` `[1]`, `number`
 * **Required**: No
@@ -544,10 +544,10 @@ An object defining a global 4-component numeric property value for all features.
 
 
 ---------------------------------------
-<a name="reference-globalpropertyscalar"></a>
-### GlobalPropertyScalar
+<a name="reference-globalpropertyinteger"></a>
+### GlobalPropertyInteger
 
-An object defining a global numeric property value for all features.
+An object defining a global integer property value for all features.
 
 * **JSON schema**: [`featureTable.schema.json`](../../schema/featureTable.schema.json)
 

--- a/specification/schema/b3dm.featureTable.schema.json
+++ b/specification/schema/b3dm.featureTable.schema.json
@@ -9,9 +9,9 @@
     }, {
         "properties" : {
             "BATCH_LENGTH" : {
-                "description": "A `GlobalPropertyScalar` object defining a numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).",
+                "description": "A `GlobalPropertyInteger` object defining an integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics).",
                 "allOf" : [{
-                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyInteger"
                 }]
             },
             "RTC_CENTER" : {

--- a/specification/schema/featureTable.schema.json
+++ b/specification/schema/featureTable.schema.json
@@ -50,9 +50,9 @@
             "description": "An object defining a global boolean property value for all features.",
             "type" : "boolean"
         },
-        "globalPropertyScalar" : {
-            "title": "GlobalPropertyScalar",
-            "description": "An object defining a global numeric property value for all features.",
+        "globalPropertyInteger" : {
+            "title": "GlobalPropertyInteger",
+            "description": "An object defining a global integer property value for all features.",
             "oneOf" : [{
                 "type" : "object",
                 "properties" : {
@@ -64,12 +64,23 @@
                 },
                 "required" : ["byteOffset"]
             }, {
-                "type" : "array",
-                "items" : {
-                    "type" : "number"
+                "type" : "integer",
+                "minimum" : 0
+            }]
+        },
+        "globalPropertyNumber" : {
+            "title": "GlobalPropertyNumber",
+            "description": "An object defining a global numeric property value for all features.",
+            "oneOf" : [{
+                "type" : "object",
+                "properties" : {
+                    "byteOffset" : {
+                        "type" : "integer",
+                        "description": "The offset into the buffer in bytes.",
+                        "minimum" : 0
+                    }
                 },
-                "minItems" : 1,
-                "maxItems" : 1
+                "required" : ["byteOffset"]
             }, {
                 "type" : "number",
                 "minimum" : 0

--- a/specification/schema/i3dm.featureTable.schema.json
+++ b/specification/schema/i3dm.featureTable.schema.json
@@ -63,9 +63,9 @@
                 }]
             },
             "INSTANCES_LENGTH" : {
-                "description": "A `GlobalPropertyScalar` object defining a numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+                "description": "A `GlobalPropertyInteger` object defining an integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
                 "allOf" : [{
-                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyInteger"
                 }]
             },
             "RTC_CENTER" : {

--- a/specification/schema/pnts.featureTable.schema.json
+++ b/specification/schema/pnts.featureTable.schema.json
@@ -57,9 +57,9 @@
                 }]
             },
             "POINTS_LENGTH" : {
-                "description": "A `GlobalPropertyScalar` object defining a numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "description": "A `GlobalPropertyInteger` object defining an integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
                 "allOf" : [{
-                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyInteger"
                 }]
             },
             "RTC_CENTER" : {
@@ -87,9 +87,9 @@
                 }]
             },
             "BATCH_LENGTH" : {
-                "description": "A `GlobalPropertyScalar` object defining a numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+                "description": "A `GlobalPropertyInteger` object defining an integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
                 "allOf" : [{
-                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyScalar"
+                    "$ref" : "featureTable.schema.json#/definitions/globalPropertyInteger"
                 }]
             },
             "extensions" : {


### PR DESCRIPTION
- Add and use `GlobalPropertyInteger` to properly serialize/deserialize feature table lengths
- Rename `GlobalPropertyScalar` -> `GlobalPropertyNumber` to be consistent with JSON primitive names
- Remove the one-element array variant for both of these