### PR TITLE
Add `TILE_GEOMETRIC_ERROR` semantic

### DIFF
--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -137,6 +137,13 @@ The horizon occlusion point of the content of a tile expressed in an ellipsoid-s
 > **Implementation Note**: Just as tile bounding volumes provide spatial coherence for traversal while content bounding volumes enable finer grained culling, the computation of `TILE_HORIZON_OCCLUSION_POINT` should account for all content in a tile and its descendants whereas `CONTENT_HORIZON_OCCLUSION_POINT` should only account for content in a tile. When the two values are equivalent only `TILE_HORIZON_OCCLUSION_POINT` should be specified.
 
 <!-- omit in toc -->
+### **TILE_GEOMETRIC_ERROR**
+
+The geometric error of the tile that overrides the geometric error implicitly calculated by [3DTILES_implicit_tiling](../../../extensions/3DTILES_implicit_tiling). This property is equivalent to `tile.geometricError`.
+
+* Type: `FLOAT32` or `FLOAT64`
+
+<!-- omit in toc -->
 ### **NAME**
 
 The name of the entity. Names do not have to be unique.


### PR DESCRIPTION
In [3DTILES_implicit_tiling](https://github.com/CesiumGS/3d-tiles/tree/3d-tiles-next/extensions/3DTILES_implicit_tiling) each child's geometric error is half of its parent's geometric error, but this imposes constraints on how the data can be tiled; in some cases you may want child tiles to be half as detailed as parent tiles but in other cases you may not, and it may vary a lot depending on the decimation algorithm. This PR adds a new semantic for implicit tile metadata that let's you specify geometric error for each tile in a subtree.

We discussed an alternate approach of specifying a geometric error factor for each subsequent level in the tree (to override the default 0.5), but it seemed better to just give full control like this.

This also gets us closer to being able to represent the whole JSON tree in binary form, which isn't really an immediate effort but is always worth thinking about.