### PR TITLE
First minor wording pass for content_gltf

### DIFF
--- a/extensions/3DTILES_content_gltf/README.md
+++ b/extensions/3DTILES_content_gltf/README.md
@@ -145,7 +145,7 @@ This section covers the differences between existing tile formats and the new gl
 <!-- omit in toc -->
 ### Batched 3D Model (b3dm)
 
-[Batched 3D Model](../../specification/TileFormats/Batched3DModel) is a wrapper around a binary glTF that includes additional information in its Feature Table and Batch Table. Batched 3D Model content can converted to a glTF content with the following changes: 
+[Batched 3D Model](../../specification/TileFormats/Batched3DModel) is a wrapper around a binary glTF that includes additional information in its Feature Table and Batch Table. Batched 3D Model content can be converted to a glTF content with the following changes: 
 
 * `RTC_CENTER` can instead be stored in a glTF node translation.
 * Batch Tables and Batch IDs can be represented using [`EXT_feature_metadata`](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata).

--- a/extensions/3DTILES_content_gltf/README.md
+++ b/extensions/3DTILES_content_gltf/README.md
@@ -34,18 +34,18 @@ This extension is required, meaning it must be placed in both the `extensionsUse
 
 ## Overview
 
-This extension allows a tileset to use [glTF](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0) models directly as tile content. Both `glTF` JSON and `GLB` binary formats are supported.
+This extension allows a tileset to use [glTF](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0) assets directly as tile content. Both `glTF` JSON and `GLB` binary formats are supported.
 
-Using glTF as a tile format simplifies content pipelines from creation to runtime. This allows greater compatibility with existing tools (e.g. 3D modeling software, validators, optimizers) that create or process glTF models. Runtime engines that currently support glTF can more easily support 3D Tiles.
+Using glTF as a tile format simplifies content pipelines from creation to runtime. This allows greater compatibility with existing tools (e.g. 3D modeling software, validators, optimizers) that create or process glTF assets. Runtime engines that currently support glTF can more easily support 3D Tiles.
 
 ## Extension JSON
 
-`3DTILES_content_gltf` is a property of the top-level `extensions` object and contains two optional properties:
+With this extension, the tile content may be a glTF asset. In order to allow runtime engines to determine compatibility before loading the content, any extensions that are required by the glTF asset must be declared in the `3DTILES_content_gltf` object. This is a property of the top-level tileset `extensions` object and contains two optional properties:
 
 * `extensionsUsed`: an array of glTF extensions used by glTF content in the tileset.
 * `extensionsRequired`: an array of glTF extensions required by glTF content in the tileset.
 
-Declaring glTF extensions in the tileset JSON allows runtime engines to determine compatibility before loading content.
+The following is an example of using the `3DTILES_content_gltf` extension to directly refer to a glTF asset, which in turn requires the `EXT_mesh_gpu_instancing` extension:
 
 ```json
 {
@@ -145,7 +145,7 @@ This section covers the differences between existing tile formats and the new gl
 <!-- omit in toc -->
 ### Batched 3D Model (b3dm)
 
-[Batched 3D Model](../../specification/TileFormats/Batched3DModel) is a wrapper around a binary glTF that includes includes additional information in its Feature Table and Batch Table. Batched 3D Model content can converted to a glTF content with the following changes: 
+[Batched 3D Model](../../specification/TileFormats/Batched3DModel) is a wrapper around a binary glTF that includes additional information in its Feature Table and Batch Table. Batched 3D Model content can converted to a glTF content with the following changes: 
 
 * `RTC_CENTER` can instead be stored in a glTF node translation.
 * Batch Tables and Batch IDs can be represented using [`EXT_feature_metadata`](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata).
@@ -153,21 +153,21 @@ This section covers the differences between existing tile formats and the new gl
 <!-- omit in toc -->
 ### Instanced 3D Model (i3dm)
 
-[Instanced 3D Model](../../specification/TileFormats/Instanced3DModel) instances a glTF model (embedded or external) and provides per-instance transforms and batch IDs.
+[Instanced 3D Model](../../specification/TileFormats/Instanced3DModel) instances a glTF asset (embedded or external) and provides per-instance transforms and batch IDs.
 
-* [`EXT_mesh_gpu_instancing`](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_mesh_gpu_instancing) may be used to instance glTF nodes. The extension supports per-instance translations, rotations, and scales. 
 * `RTC_CENTER` can instead be stored in a glTF node translation.
+* [`EXT_mesh_gpu_instancing`](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_mesh_gpu_instancing) may be used to instance glTF assets. The extension supports per-instance translations, rotations, and scales. 
 * Batch Table and Batch IDs can be represented using [`EXT_feature_metadata`](https://github.com/CesiumGS/glTF/blob/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata). Per-instance and multi-instance metadata is supported.
 * `EAST_NORTH_UP` is not directly supported, but can be represented using per-instance rotations.
 
 <!-- omit in toc -->
 ### Point Cloud (pnts)
 
-[Point Cloud](../../specification/TileFormats/PointCloud) can be represented as a glTF using the primitive mode `0` (`POINT`).
+[Point Cloud](../../specification/TileFormats/PointCloud) can be represented as a glTF using the primitive mode `0` (`POINTS`).
 
+* `RTC_CENTER` can instead be stored in a glTF node translation.
 * Feature table properties like `POSITION`, `COLOR`, and `NORMAL` may be stored as glTF attributes.
 * [`EXT_meshopt_compression`](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_meshopt_compression) and [`KHR_mesh_quantization`](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_mesh_quantization) may be used for point cloud compression. [`3DTILES_draco_point_compression`](../3DTILES_draco_point_compression) is not directly supported in glTF because [`KHR_draco_mesh_compression`](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_draco_mesh_compression) only supports triangle meshes.
-* `RTC_CENTER` can instead be stored in a glTF node translation.
 * Batch Table and Batch IDs can be represented using [`EXT_feature_metadata`](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata). The extension supports both per-point metadata and multi-point metadata in the same glTF.
 * `CONSTANT_RGBA` is not directly supported in glTF, but can be represented by using per-point colors or runtime styling using [`EXT_feature_metadata`](https://github.com/CesiumGS/glTF/blob/3d-tiles-next/extensions/2.0/Vendor/EXT_feature_metadata).
 


### PR DESCRIPTION

 - Renamed "glTF model" to "glTF asset", roughly inspired by https://github.com/CesiumGS/glTF/pull/4#discussion_r588887487

 - I tried to explain the "Why" before the "How" for using the `3DTILES_content_gltf` structure to declare the extensions that are used by the glTF asset. I found the naming a bit confusing at the first glance, and wonder why the name was changed from `gltfExtensionsUsed` to `extensionsUsed` in  https://github.com/CesiumGS/3d-tiles/commit/bc21c2c67e76a537bbba2a91a83475efb6581027#diff-ca64f943dc5ef8ec5baabf371a7dffd2270adb6a64b4456fd98b8d87b43c0790 ...

The "Comparison with Existing Tile Formats" section may need some polishing:
 
 - The links will have to be updated at some point

 - Some technical terms have to be reviewed to be consistent with other specs (e.g. "information" vs. "metadata" vs. "properties"). 

 - I actually started changing "to instance" to "to instantiate" (c.f. https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/Specification.adoc#374-instantiation ), but for the sake of consistency with the Instanced3DModel spec, did not do this, eventually. 

 - Do we go all the way of using "may" as in https://www.rfc-editor.org/rfc/rfc2119.txt ? (Then, we could omit the word "can"...)

 - Not being a native English speaker, I can only say that I'd write "Batched 3D Model content can be converted into glTF content" instead of "Batched 3D Model content can converted to a glTF content", but that may also be wrong (or it may not matter at all). At least, I'm reasonably sure about the missing "be"...

 - I was tempted to rephrase the common statement 
   - `RTC_CENTER` can instead be stored in a glTF node translation.
   to
   - The `RTC_CENTER` can be added to the translation component of the root node of the glTF asset
   but that may sound too convoluted...
   
   


 
 