### PR TITLE
Fix example sparse implicit octree tileset

### DIFF
--- a/extensions/3DTILES_implicit_tiling/examples/sparseOctree/tileset.json
+++ b/extensions/3DTILES_implicit_tiling/examples/sparseOctree/tileset.json
@@ -17,7 +17,7 @@
     "refine": "ADD",
     "geometricError": 5000,
     "content": {
-      "uri": "content/{level}/{x}/{y}/{z}.b3dm"
+      "uri": "content/{level}/{x}/{y}/{z}.pnts"
     },
     "extensions": {
       "3DTILES_implicit_tiling": {


### PR DESCRIPTION
The templated content uri was mistakenly using ".b3dm" file type even though the actual content are all "pnts".