### PR TITLE
Core Metadata: Rewrite 'JSON Table Format' example with less JSON

### DIFF
--- a/specification/Metadata/README.md
+++ b/specification/Metadata/README.md
@@ -369,7 +369,7 @@ Property values are encoded as their corresponding JSON types: numeric types are
 >
 > | id                  | type       | componentType | componentCount | enumType      | required |
 > |---------------------|------------|---------------|----------------|---------------|----------|
-> | floatProperty       | `"SINGLE"` | `"FLOAT64"`   |                |               | ✓        |
+> | floatProperty       | `"SINGLE"` (default) | `"FLOAT64"`   |                |               | ✓        |
 > | integerProperty     | `"SINGLE"` | `"INT32"`     |                |               | ✓        |
 > | booleanProperty     | `"SINGLE"` | `"BOOLEAN"`   |                |               | ✓        |
 > | stringProperty      | `"SINGLE"` | `"STRING"`    |                |               | ✓        |


### PR DESCRIPTION
*Continued from https://github.com/CesiumGS/3d-tiles/pull/511.*