### PR TITLE
Multiple contents wording

### DIFF
--- a/extensions/3DTILES_multiple_contents/README.md
+++ b/extensions/3DTILES_multiple_contents/README.md
@@ -100,7 +100,7 @@ Each content object may optionally have a `boundingVolume` that tightly fits the
 
 ### Metadata Groups
 
-This extension may be paired with the [`3DTILES_metadata`](../3DTILES_metadata) extension to assign each content to a group associated with some metadata. Each content within a `3DTILES_multiple_contents` extension may then contain a `3DTILES_metadata` extension object, identifying a group for the content. The available groups and their schema are defined in the `3DTILES_metadata` object of the surrounding tileset.
+This extension may be paired with the [`3DTILES_metadata`](../3DTILES_metadata) extension to assign each content to a group. The group provides metadata properties that conform to a class. Each content within a `3DTILES_multiple_contents` extension may then contain a `3DTILES_metadata` extension object, identifying a group for the content. The available groups and their schema are defined in the `3DTILES_metadata` object of the surrounding tileset.
 
 > **Example:** A tileset where the root tile uses the `3DTILES_multiple_contents` extension to refer to two different content files. The first content uses the `3DTILES_metadata` extension to assign it to a group called `"buildings"`. The second one is assigned to a group called `"trees"`. The schema contains entity definitions for these groups. Both entities belong to the class `"layer"` that is also defined in the schema, and contain the values for the properties of this class.
 > ```jsonc


### PR DESCRIPTION
Direct preview link: https://github.com/javagl/3d-tiles/blob/multiple-contents-wording/extensions/3DTILES_multiple_contents/README.md

- Extended the descriptions of the examples (and indented them as "Example")
- Minor restructuring of the TOC
  - Separated the core concept from the three cases of combining it with other extensions (namely "+groups", "+implict", and "+groups+implicit". This could probably be shortened by only showing the new/relevant part of the JSON, but I wasn't sure whether this was desired...
- Removed schema reference, added links to schema files
- Tried to reconstruct the revision history

