### PR TITLE
Fix for tile.content being renamed to content

### DIFF
--- a/extensions/3DTILES_multiple_contents/schema/tile.3DTILES_multiple_contents.schema.json
+++ b/extensions/3DTILES_multiple_contents/schema/tile.3DTILES_multiple_contents.schema.json
@@ -14,7 +14,7 @@
             "type": "array",
             "description": "An array of contents.",
             "items": {
-                "$ref": "tile.content.schema.json"
+                "$ref": "content.schema.json"
             },
             "minItems": 1
         },

--- a/specification/schema/content.schema.json
+++ b/specification/schema/content.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "tile.content.schema.json",
+    "$id": "content.schema.json",
     "title": "Content",
     "type": "object",
     "description": "Metadata about the tile's content and a link to the content.",


### PR DESCRIPTION
The ID had been wrong, and it was still referred to by its old name from another schema.