### PR TITLE
Rename Cesium 3D Metadata Specification for consistency

### DIFF
--- a/extensions/3DTILES_implicit_tiling/README.md
+++ b/extensions/3DTILES_implicit_tiling/README.md
@@ -398,7 +398,7 @@ Some child subtrees exist, so `childSubtreeAvailability.bufferView` refers to an
 
 ### Availability Packing
 
-Availability bitstreams are packed in binary using the format described in the [Booleans](../../specification/Metadata#booleans) section of the Cesium 3D Metadata Specification.
+Availability bitstreams are packed in binary using the format described in the [Booleans](../../specification/Metadata#booleans) section of the 3D Metadata Specification.
 
 ## Glossary
 

--- a/extensions/3DTILES_implicit_tiling/schema/subtree/availability.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/subtree/availability.schema.json
@@ -11,7 +11,7 @@
     ],
     "properties": {
         "bufferView": {
-            "description": "Index of a buffer view that indicates whether each element is available. The bitstream conforms to the boolean array encoding described in the [Cesium 3D Metadata specification](../../specification/Metadata). If an element is available, its bit is 1, and if it is unavailable, its bit is 0. The `bufferView` `byteOffset` must be aligned to a multiple of 8 bytes.",
+            "description": "Index of a buffer view that indicates whether each element is available. The bitstream conforms to the boolean array encoding described in the [3D Metadata specification](../../specification/Metadata). If an element is available, its bit is 1, and if it is unavailable, its bit is 0. The `bufferView` `byteOffset` must be aligned to a multiple of 8 bytes.",
             "type": "integer",
             "minimum": 0
         },

--- a/extensions/3DTILES_metadata/README.md
+++ b/extensions/3DTILES_metadata/README.md
@@ -67,7 +67,7 @@ This extension defines a means of including structured metadata ("properties") i
 
 > **Implementation note:** Certain subcomponents of tile content ("features") may also have associated metadata. See [Content Feature Properties](#content-feature-properties).
 
-Concepts and terminology used throughout this document refer to the [Cesium 3D Metadata Specification](../../specification/Metadata/README.md), which should be considered a normative reference for definitions and requirements. This document provides inline definitions of terms where appropriate.
+Concepts and terminology used throughout this document refer to the [3D Metadata Specification](../../specification/Metadata/README.md), which should be considered a normative reference for definitions and requirements. This document provides inline definitions of terms where appropriate.
 
 The figure below shows the relationship between entities (tilesets, tiles, contents, and groups) in 3D Tiles:
 
@@ -94,7 +94,7 @@ Metadata in 3D Tiles enables additional use cases and functionality for the form
 
 *Defined in [schema.schema.json](./schema/schema.schema.json).*
 
-A schema defines a set of classes and enums used in a tileset. Classes serve as templates for entities - they provide a list of properties and the type information for those properties. Enums define the allowable values for enum properties. `3DTILES_metadata` implements the [Cesium 3D Metadata Specification](../../specification/Metadata), which describes the metadata format and property definitions in full detail.
+A schema defines a set of classes and enums used in a tileset. Classes serve as templates for entities - they provide a list of properties and the type information for those properties. Enums define the allowable values for enum properties. `3DTILES_metadata` implements the [3D Metadata Specification](../../specification/Metadata), which describes the metadata format and property definitions in full detail.
 
 Schemas may be embedded in tilesets with the `schema` property, or referenced externally by the `schemaUri` property. Multiple tilesets and glTF contents may refer to the same schema to avoid duplication.
 
@@ -209,7 +209,7 @@ Set of categorical types, defined as `(name, value)` pairs. Enum properties use 
 
 Enums are defined as entries in the `schema.enums` dictionary, indexed by an alphanumeric enum ID.
 
-> **Example:** A "Quality" enum defining quality level of data within a tile. An "Unspecified" enum value is optional, but when provided as the `noData` value for a property (see: [Cesium 3D Metadata → No Data Values](../../specification/Metadata#required-properties-and-no-data-values)) may be helpful to identify missing data.
+> **Example:** A "Quality" enum defining quality level of data within a tile. An "Unspecified" enum value is optional, but when provided as the `noData` value for a property (see: [3D Metadata → No Data Values](../../specification/Metadata#required-properties-and-no-data-values)) may be helpful to identify missing data.
 >
 > ```jsonc
 > {
@@ -424,7 +424,7 @@ A `3DTILES_metadata` extension on a tile object must specify its class (`class`)
 
 When tiles are listed explicitly within a tileset, each tile's metadata is also embedded explicitly within the tile definition. When the tile hierarchy is _implicit_, as enabled by [`3DTILES_implicit_tiling`](../3DTILES_implicit_tiling), tiles are not listed exhaustively and metadata cannot be directly embedded in tile definitions. To support metadata for tiles within implicit tiling schemes, the `3DTILES_metadata` extension provides an additional metadata storage mechanism compatible with `3DTILES_implicit_tiling`.
 
-Unlike other methods of assigning metadata, properties of implicit tiles are not encoded as JSON objects. Instead, property values for all available tile contents are encoded in a compact [*Binary Table Format*](../../specification/Metadata/README.md#binary-table-format) defined by the Cesium 3D Metadata Specification. The binary representation is particularly efficient for larger datasets with many tiles.
+Unlike other methods of assigning metadata, properties of implicit tiles are not encoded as JSON objects. Instead, property values for all available tile contents are encoded in a compact [*Binary Table Format*](../../specification/Metadata/README.md#binary-table-format) defined by the 3D Metadata Specification. The binary representation is particularly efficient for larger datasets with many tiles.
 
  Tile metadata exists only for available tiles and is tightly packed by an increasing tile index according to the [Availability Ordering](../3DTILES_implicit_tiling/README.md#availability). Each available tile must have a value — representation of missing values within a tile is possible only with the `noData` indicator defined by the *Binary Table Format*.
 
@@ -557,7 +557,7 @@ Certain kinds of tile content may contain meaningful subcomponents ("features"),
 
 Assigning properties to tile content is not within the scope of this extension, but may be defined by other specifications. One such example is the glTF extension, [`EXT_mesh_features`](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_mesh_features), which supports definitions of conceptual features within geometry and textures, and associated metadata. glTF 2.0 assets with feature metadata may be included as tile contents with the [`3DTILES_content_gltf`](../3DTILES_content_gltf) extension.
 
-While `3DTILES_metadata` and `EXT_mesh_features` are defined independently, both conform to the [Cesium 3D Metadata Specification](../../specification/Metadata/README.md) and share the same representation of metadata as schema and properties.
+While `3DTILES_metadata` and `EXT_mesh_features` are defined independently, both conform to the [3D Metadata Specification](../../specification/Metadata/README.md) and share the same representation of metadata as schema and properties.
 
 ## Schema
 

--- a/extensions/3DTILES_metadata/README.md
+++ b/extensions/3DTILES_metadata/README.md
@@ -177,7 +177,7 @@ Allowed values for `type`:
 
 Class properties are defined as entries in the `class.properties` dictionary, indexed by an alphanumeric property ID.
 
-By default, properties do not have any inherent meaning. A property may be assigned a **semantic**, an identifier that describes a property's meaning, for higher-level type information, runtime behavior, or other interpretation. The list of built-in semantics can be found in the [Cesium Metadata Semantic Reference](../../specification/Metadata/Semantics). Tileset authors may define their own application- or domain-specific semantics separately, and should follow the naming conventions in the Semantic Reference.
+By default, properties do not have any inherent meaning. A property may be assigned a **semantic**, an identifier that describes a property's meaning, for higher-level type information, runtime behavior, or other interpretation. The list of built-in semantics can be found in the [3D Metadata Semantic Reference](../../specification/Metadata/Semantics). Tileset authors may define their own application- or domain-specific semantics separately, and should follow the naming conventions in the Semantic Reference.
 
 > **Example:** Schema defining a "building" class. The class's properties use two built-in semantics, `NAME` and `ID`, and one custom semantic, `_HEIGHT`.
 >
@@ -373,7 +373,7 @@ The `tileset` object within a tileset's `3DTILES_metadata` extension must specif
 
 *Defined in [tileset.3DTILES_metadata.schema.json](./schema/tile.3DTILES_metadata.schema.json)*.
 
-Property values may be assigned to individual tiles, including (for example) spatial hints to optimize traversal algorithms. The example below uses the built-in semantic `TILE_MAXIMUM_HEIGHT` from the [Cesium Metadata Semantic Reference](../../specification/Metadata/Semantics).
+Property values may be assigned to individual tiles, including (for example) spatial hints to optimize traversal algorithms. The example below uses the built-in semantic `TILE_MAXIMUM_HEIGHT` from the [3D Metadata Semantic Reference](../../specification/Metadata/Semantics).
 
 A `3DTILES_metadata` extension on a tile object must specify its class (`class`). Within a `properties` dictionary, values for properties are given, encoded as JSON types according to the [JSON Table Format](../../specification/Metadata/README.md#json-table-format) specification.
 

--- a/specification/Metadata/README.md
+++ b/specification/Metadata/README.md
@@ -66,7 +66,7 @@ The specification defines core concepts to be used by multiple 3D formats, and i
 * [`3DTILES_metadata`](../../extensions/3DTILES_metadata) (3D Tiles 1.0) — Assigns metadata to tilesets, tiles, or tile contents
 * [`EXT_mesh_features`](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_mesh_features) (glTF 2.0) —  Assigns metadata to subcomponents ("features") of geometry or textures
 
-The specification does not enumerate or define the semantic meanings of metadata, and assumes that separate specifications will define semantics for their particular application or domain. One example is the [Cesium Metadata Semantic Reference](./Semantics/) which defines built-in semantics for 3D Tiles and glTF. Identifiers for externally-defined semantics can be stored within the 3D Metadata Specification.
+The specification does not enumerate or define the semantic meanings of metadata, and assumes that separate specifications will define semantics for their particular application or domain. One example is the [3D Metadata Semantic Reference](./Semantics/) which defines built-in semantics for 3D Tiles and glTF. Identifiers for externally-defined semantics can be stored within the 3D Metadata Specification.
 
 ## Concepts
 
@@ -149,7 +149,7 @@ Descriptions (`description`) provide a human-readable explanation of a property,
 
 #### Semantic
 
-Property IDs, names, and descriptions do not have an inherent meaning. To provide a machine-readable meaning, properties may be assigned a semantic identifier string (`semantic`), indicating how the property's content should be interpreted. Semantic identifiers may be defined by the [Cesium Metadata Semantic Reference](./Semantics/) or by external semantic references, and may be application-specific. Identifiers should be uppercase, with underscores as word separators.
+Property IDs, names, and descriptions do not have an inherent meaning. To provide a machine-readable meaning, properties may be assigned a semantic identifier string (`semantic`), indicating how the property's content should be interpreted. Semantic identifiers may be defined by the [3D Metadata Semantic Reference](./Semantics/) or by external semantic references, and may be application-specific. Identifiers should be uppercase, with underscores as word separators.
 
 > **Example:** Semantic definitions might include temperature in degrees Celsius (e.g. `TEMPERATURE_DEGREES_CELSIUS`), time in milliseconds (e.g. `TIME_MILLISECONDS`), or mean squared error (e.g. `MEAN_SQUARED_ERROR`). These examples are only illustrative.
 

--- a/specification/Metadata/README.md
+++ b/specification/Metadata/README.md
@@ -1,5 +1,5 @@
 <!-- omit in toc -->
-# Cesium 3D Metadata Specification
+# 3D Metadata Specification
 
 <!-- omit in toc -->
 ## Contributors
@@ -57,7 +57,7 @@ Draft
 
 ## Overview
 
-The Cesium 3D Metadata Specification defines a standard format for structured metadata in 3D content. Metadata — represented as entities and properties — may be closely associated with parts of 3D content, with data representations appropriate for large, distributed datasets. For the most detailed use cases, properties allow vertex- and texel-level associations; higher-level property associations are also supported.
+The 3D Metadata Specification defines a standard format for structured metadata in 3D content. Metadata — represented as entities and properties — may be closely associated with parts of 3D content, with data representations appropriate for large, distributed datasets. For the most detailed use cases, properties allow vertex- and texel-level associations; higher-level property associations are also supported.
 
 Many domains benefit from structured metadata — typical examples include historical details of buildings in a city, names of components in a CAD model, descriptions of regions on textured surfaces, and classification codes for point clouds.
 
@@ -66,7 +66,7 @@ The specification defines core concepts to be used by multiple 3D formats, and i
 * [`3DTILES_metadata`](../../extensions/3DTILES_metadata) (3D Tiles 1.0) — Assigns metadata to tilesets, tiles, or tile contents
 * [`EXT_mesh_features`](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_mesh_features) (glTF 2.0) —  Assigns metadata to subcomponents ("features") of geometry or textures
 
-The specification does not enumerate or define the semantic meanings of metadata, and assumes that separate specifications will define semantics for their particular application or domain. One example is the [Cesium Metadata Semantic Reference](./Semantics/) which defines built-in semantics for 3D Tiles and glTF. Identifiers for externally-defined semantics can be stored within the Cesium 3D Metadata Specification.
+The specification does not enumerate or define the semantic meanings of metadata, and assumes that separate specifications will define semantics for their particular application or domain. One example is the [Cesium Metadata Semantic Reference](./Semantics/) which defines built-in semantics for 3D Tiles and glTF. Identifiers for externally-defined semantics can be stored within the 3D Metadata Specification.
 
 ## Concepts
 
@@ -254,7 +254,7 @@ Both formats formats are suitable for general purpose metadata storage. Binary f
 
 Additional serialization methods may be defined outside of this specification. For example, property values could be stored in texture channels or retrieved from a REST API as XML data.
 
-> **Implementation note:** Any specification that references Cesium 3D Metadata must state explicitly which storage formats are supported, or define its own serialization. For example, the [`EXT_mesh_features`](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_mesh_features) glTF extension implements the binary table format described below, and defines an additional image-based format for per-texel metadata.
+> **Implementation note:** Any specification that references 3D Metadata must state explicitly which storage formats are supported, or define its own serialization. For example, the [`EXT_mesh_features`](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_mesh_features) glTF extension implements the binary table format described below, and defines an additional image-based format for per-texel metadata.
 
 ### Binary Table Format
 

--- a/specification/Metadata/Semantics/README.md
+++ b/specification/Metadata/Semantics/README.md
@@ -1,5 +1,5 @@
 <!-- omit in toc -->
-# Cesium Metadata Semantic Reference
+# 3D Metadata Semantic Reference
 
 <!-- omit in toc -->
 ## Overview
@@ -8,7 +8,7 @@ This document provides common definitions of meaning ("semantics") used by metad
 
 Semantics describe how properties should be interpreted. For example, an application that encounters the `ID` or `NAME` semantics while parsing a dataset may use these values as unique identifiers or human-readable labels, respectively.
 
-Each semantic is defined in terms of its meaning, and the datatypes it may assume. Datatype specifications include "type", "component type", and "component count" attributes as defined by the [Cesium 3D Metadata Specification](../).
+Each semantic is defined in terms of its meaning, and the datatypes it may assume. Datatype specifications include "type", "component type", and "component count" attributes as defined by the [3D Metadata Specification](../).
 
 For use of semantics in extensions of specific standards, see:
 
@@ -44,7 +44,7 @@ For use of semantics in extensions of specific standards, see:
 <!-- omit in toc -->
 ### Overview
 
-Throughout this section, the term "entity" refers to any conceptual object with which a property value (as defined in the [Cesium 3D Metadata Specification](../)) may be associated. Examples of entities include tilesets, tiles, and tile contents in 3D Tiles, or groups of vertices and texels in glTF 2.0 assets. Additional types of entities may be defined by other specifications or applications.
+Throughout this section, the term "entity" refers to any conceptual object with which a property value (as defined in the [3D Metadata Specification](../)) may be associated. Examples of entities include tilesets, tiles, and tile contents in 3D Tiles, or groups of vertices and texels in glTF 2.0 assets. Additional types of entities may be defined by other specifications or applications.
 
 ### `ID`
 


### PR DESCRIPTION
This renames:

* Cesium 3D Metadata Specification -> 3D Metadata Specification
* Cesium Metadata Semantic Reference -> 3D Metadata Semantic Reference

Could you review @lilleyse?