### PR TITLE
Add 3D Tiles Next links to extensions landing page

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -2,6 +2,19 @@
 
 ## Extensions
 
+### 3D Tiles Next Extensions:
+
+3D Tiles Next is a collection of draft extensions to advance 3D Tiles. It provides extensions for cleaner integration with the glTF ecosystem, rich semantic metadata, and efficient spatial indexes for scalable simulations.
+the [3D Tiles Next](../next) page for more details.
+
+* [3DTILES_content_gltf](./3DTILES_content_gltf)
+* [3DTILES_multiple_contents](./3DTILES_multiple_contents)
+* [3DTILES_metadata](./3DTILES_metadata)
+* [3DTILES_implicit_tiling](./3DTILES_implicit_tiling)
+* [3DTILES_bounding_volume_S2](./3DTILES_bounding_volume_S2)
+
+### Other Extensions:
+
 * [3DTILES_batch_table_hierarchy](./3DTILES_batch_table_hierarchy/)
 * [3DTILES_draco_point_compression](./3DTILES_draco_point_compression/)
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -2,10 +2,9 @@
 
 ## Extensions
 
-### 3D Tiles Next Extensions:
+### 3D Tiles Next
 
-3D Tiles Next is a collection of draft extensions to advance 3D Tiles. It provides extensions for cleaner integration with the glTF ecosystem, rich semantic metadata, and efficient spatial indexes for scalable simulations.
-the [3D Tiles Next](../next) page for more details.
+3D Tiles Next is a collection of draft extensions to advance 3D Tiles. It provides extensions for cleaner integration with the glTF ecosystem, rich semantic metadata, and efficient spatial indexes for scalable simulations. See the [3D Tiles Next](../next) page for more details.
 
 * [3DTILES_content_gltf](./3DTILES_content_gltf)
 * [3DTILES_multiple_contents](./3DTILES_multiple_contents)
@@ -13,7 +12,7 @@ the [3D Tiles Next](../next) page for more details.
 * [3DTILES_implicit_tiling](./3DTILES_implicit_tiling)
 * [3DTILES_bounding_volume_S2](./3DTILES_bounding_volume_S2)
 
-### Other Extensions:
+### Other
 
 * [3DTILES_batch_table_hierarchy](./3DTILES_batch_table_hierarchy/)
 * [3DTILES_draco_point_compression](./3DTILES_draco_point_compression/)

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -70,4 +70,4 @@ All extensions used in a tileset or any descendant external tilesets must be lis
 }
 ```
 
-All extensions required to load and render a tileset or any descendant external tilesets must also be listed in the tileset JSON in the top-level `extensionsRequired` array property, such that `extensionsRequired` is a subset of `extensionsUsed`. All values in `extensionsRequired` must also exist in `extensionsUsed`.
+All extensions required to load and render a tileset or any descendant external tilesets must be listed in the tileset JSON in the top-level `extensionsRequired` array. Extensions in `extensionsRequired` must also be listed in `extensionsUsed`.


### PR DESCRIPTION
Updated links to the extensions page for the new 3D Tiles Next extensions.

@donmccurdy could you review?

[Landing page](https://github.com/CesiumGS/3d-tiles/tree/update-extension-links/extensions)