### PR TITLE
Allow property values to be stored in JSON header

### DIFF
--- a/specification/TileFormats/Instanced3DModel/README.md
+++ b/specification/TileFormats/Instanced3DModel/README.md
@@ -81,7 +81,6 @@ See [Property reference](#property-reference) for the `i3dm` feature table schem
 #### Instance semantics
 
 These semantics map to an array of feature values that are used to create instances. The length of these arrays must be the same for all semantics and is equal to the number of instances.
-The value for each instance semantic must be a reference to the Feature Table binary body; they cannot be embedded in the Feature Table JSON header.
 
 If a semantic has a dependency on another semantic, that semantic must be defined.
 If both `SCALE` and `SCALE_NON_UNIFORM` are defined for an instance, both scaling operations will be applied.

--- a/specification/TileFormats/PointCloud/README.md
+++ b/specification/TileFormats/PointCloud/README.md
@@ -76,7 +76,6 @@ See [Property reference](#property-reference) for the `pnts` feature table schem
 #### Point semantics
 
 These semantics map to an array of feature values that define each point. The length of these arrays must be the same for all semantics and is equal to the number of points.
-The value for each point semantic must be a reference to the Feature Table binary body; they cannot be embedded in the Feature Table JSON header.
 
 If a semantic has a dependency on another semantic, that semantic must be defined.
 If both `POSITION` and `POSITION_QUANTIZED` are defined for a point, the higher precision `POSITION` will be used.


### PR DESCRIPTION
May fix https://github.com/CesiumGS/3d-tiles/issues/396 :  

The section for "Instance Semantics" said

> The value for each instance semantic must be a reference to the Feature Table binary body; they cannot be embedded in the Feature Table JSON header.

(analogously, for PNTS and "Point Semantics"). This statement is removed with this PR, because it is allowed to store these values in the JSON header as well. 

Note that this may be conisdered as a "breaking change": Existing implementations may have _relied_ on this restriction. Specifically, they may not handle the case where the values are supposed to be obtained from the JSON header arrays, as it is currently done at https://github.com/CesiumGS/cesium/blob/2fd0e8f7e4212bd1e7084299187f70597a6bbfd8/Source/Scene/Cesium3DTileFeatureTable.js#L97

