### PR TITLE
Disallow per-feature property values in JSON header

### DIFF
--- a/specification/TileFormats/FeatureTable/README.md
+++ b/specification/TileFormats/FeatureTable/README.md
@@ -36,13 +36,11 @@ Binary properties must start at a byte offset that is a multiple of the size in 
 
 ### JSON header
 
-Feature Table values can be represented in the JSON header in three different ways:
+Feature Table values can be represented in the JSON header in two different ways:
 
 1. A single value or object, e.g., `"INSTANCES_LENGTH" : 4`.
    * This is used for global semantics like `"INSTANCES_LENGTH"`, which defines the number of model instances in an Instanced 3D Model tile.
-2. An array of values, e.g., `"POSITION" : [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]`.
-   * This is used for per-feature semantics like `"POSITION"` in Instanced 3D Model.  Above, each `POSITION` refers to a `float32[3]` data type so there are three features: `Feature 0's position`=`(1.0, 0.0, 0.0)`, `Feature 1's position`=`(0.0, 1.0, 0.0)`, `Feature 2's position`=`(0.0, 0.0, 1.0)`.
-3. A reference to data in the binary body, denoted by an object with a `byteOffset` property, e.g., `"SCALE" : { "byteOffset" : 24}`.
+2. A reference to data in the binary body, denoted by an object with a `byteOffset` property, e.g., `"SCALE" : { "byteOffset" : 24}`.
    * `byteOffset` specifies a zero-based offset relative to the start of the binary body. The value of `byteOffset` must be a multiple of the size in bytes of the property's implicit component type, e.g., the `"POSITION"` property has the component type `FLOAT` (4 bytes), so the value of `byteOffset` must be of a multiple of `4`.
    * The semantic defines the allowed data type, e.g., when `"POSITION"` in Instanced 3D Model refers to the binary body, the component type is `FLOAT` and the number of components is `3`.
    * Some semantics allow for overriding the implicit component type. These cases are specified in each tile format, e.g., `"BATCH_ID" : { "byteOffset" : 24, "componentType" : "UNSIGNED_BYTE"}`.

--- a/specification/schema/featureTable.schema.json
+++ b/specification/schema/featureTable.schema.json
@@ -75,7 +75,19 @@
                     "$ref": "#/definitions/binaryBodyReference"
                 },
                 {
-                    "type": "number"
+                    "$ref": "#/definitions/globalPropertyBoolean"
+                },
+                {
+                    "$ref": "#/definitions/globalPropertyInteger"
+                },
+                {
+                    "$ref": "#/definitions/globalPropertyNumber"
+                },
+                {
+                    "$ref": "#/definitions/globalPropertyCartesian3"
+                },
+                {
+                    "$ref": "#/definitions/globalPropertyCartesian4"
                 }
             ]
         },

--- a/specification/schema/featureTable.schema.json
+++ b/specification/schema/featureTable.schema.json
@@ -67,24 +67,12 @@
                 "byteOffset"
             ]
         },
-        "numericArray": {
-            "type": "array",
-            "items": {
-                "type": "number"
-            }
-        },
         "property": {
             "title": "Property",
-            "description": "A user-defined property which specifies per-feature application-specific metadata in a tile. Values either can be defined directly in the JSON as an array, or can refer to sections in the binary body with a `BinaryBodyReference` object.",
+            "description": "A user-defined property which specifies application-specific metadata in a tile. Values can refer to sections in the binary body with a `BinaryBodyReference` object. Global values can be also be defined directly in the JSON.",
             "oneOf": [
                 {
                     "$ref": "#/definitions/binaryBodyReference"
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "number"
-                    }
                 },
                 {
                     "type": "number"


### PR DESCRIPTION
This may fix https://github.com/CesiumGS/3d-tiles/issues/396. It replaces https://github.com/CesiumGS/3d-tiles/pull/566 , where the conflict was resolved in the opposite way. According to a comment there, it should not be possible to store per-feature properties in arrays in the JSON header, and the schema should be updated accordingly. 

But... some things to sort out: 

The schema supported storing arrays in the header. Only the *text* said that these arrays were not allowed to be **per-feature** values. But these arrays may have served the purpose of having a **global** "vector" or "matrix" (represented as an array). Now, the only way to store a global array-typed value is with a `binaryBodyReference`...

@lilleyse This might be an unintended side-effect, and be a limitation that may be hard to justify. 

Or more specifically, in https://github.com/CesiumGS/3d-tiles/pull/566#issuecomment-970429559 you said

> I think the better change would be to remove the second option in https://github.com/CesiumGS/3d-tiles/blob/main/specification/TileFormats/FeatureTable/README.md#json-header.

and I now wondered what "better" means...

---

An aside: The `featureTable.schema.json` contained a definition for a type `numericArray`. While this could be useful (and it could have been used in place of the part of the definition that is now removed), it actually has not been used at all. So I also removed it from the definition here. 

