### PR TITLE
Add clarifications about metadata groups in multiple contents

### DIFF
--- a/extensions/3DTILES_multiple_contents/README.md
+++ b/extensions/3DTILES_multiple_contents/README.md
@@ -90,7 +90,7 @@ When this extension is used the tile's `content` property must be omitted.
 
 ### Metadata Groups
 
-This extension may be paired with the [`3DTILES_metadata` extension](../3DTILES_metadata) to assign metadata to each content.
+This extension may be paired with the [`3DTILES_metadata` extension](../3DTILES_metadata) to store properties that are constant across one or more tile contents. Each content may be optionally added to one of the metadata groups by adding a `3DTILES_metadata` extension with a `group` property that identifies one of the metadata groups.
 
 ```jsonc
 {


### PR DESCRIPTION
Added a couple of clarifications about metadata groups:

* contents do not have to be added to a group, it's optional
* mention that group metadata is constant across one or more tile contents.

@javagl could you review?