### PR TITLE
Add developer resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Bringing techniques from the field of 3D graphics and built on [glTF](https://gi
 * [3D Tiles Format Specification](./specification/)
 * [3D Tiles Extension Registry](./extensions/)
 
-Please provide spec feedback by [submitting issues](https://github.com/CesiumGS/3d-tiles/issues). For questions on implementation, generating 3D Tiles, or to showcase your work, join the [Cesium community forum](https://community.cesium.com/).
+Please provide spec feedback by [submitting issues](https://github.com/CesiumGS/3d-tiles/issues). For questions on implementation, generating 3D Tiles, or to showcase your work, join the [Cesium community forum](https://community.cesium.com/). A list of resources for developers, including blog posts and presentations that explain the concepts and applications of 3D Tiles, can be found on the [3D Tiles Resources](./next/RESOURCES.md) page.
 
 ### Upcoming
 
@@ -41,6 +41,8 @@ Please provide spec feedback by [submitting issues](https://github.com/CesiumGS/
 - [Tile Content](./next#tile-content): glTF 2.0 assets may be used directly as tile content, without intermediate formats, improving interoperability with 3D content and tooling ecosystems. Tiles may reference multiple contents — for organization, styling, and filtering — and contents may be collected into groups similar to map layers in mapping applications.
 - [Implicit Tiling](./next#implicit-tiling): Common subdivision schemes and spatial index patterns may be declared without listing bounding volumes exhaustively. Reduces tileset size, and enables new optimizations including faster traversal, raycasting, random access, and spatial queries.
 - [Metadata](./next#metadata): Metadata in 3D Tiles gains more expressiveness and flexibility, with a well-defined type system, new encoding options (e.g. JSON or binary), and a range of granularity options. Metadata may be associated with high-level objects like tilesets, tiles, or tile content groups, or with individual vertices and texels on glTF 2.0 geometry.
+
+A curated list of resources for developers can be found on the [3D Tiles Next Resources](./next/RESOURCES.md) page.
 
 ## 3D Tiles Ecosystem
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Bringing techniques from the field of 3D graphics and built on [glTF](https://gi
 * [3D Tiles Format Specification](./specification/)
 * [3D Tiles Extension Registry](./extensions/)
 
-Please provide spec feedback by [submitting issues](https://github.com/CesiumGS/3d-tiles/issues). For questions on implementation, generating 3D Tiles, or to showcase your work, join the [Cesium community forum](https://community.cesium.com/). A list of resources for developers, including blog posts and presentations that explain the concepts and applications of 3D Tiles, can be found on the [3D Tiles Resources](./next/RESOURCES.md) page.
+Please provide spec feedback by [submitting issues](https://github.com/CesiumGS/3d-tiles/issues). For questions on implementation, generating 3D Tiles, or to showcase your work, join the [Cesium community forum](https://community.cesium.com/). A list of resources for developers, including blog posts and presentations that explain the concepts and applications of 3D Tiles, can be found on the [3D Tiles Resources](./RESOURCES.md) page.
 
 ### Upcoming
 

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -1,4 +1,4 @@
-## Resources and Related Links
+## 3D Tiles Resources
 
 * [**Introducing 3D Tiles**](https://cesium.com/blog/2015/08/10/introducing-3d-tiles/) - the motivation for and principles of 3D Tiles.  Read this first if you are new to 3D Tiles.
 * [**3D Tiles Reference Card**](./3d-tiles-reference-card.pdf) - an approachable and concise guide to learning about the main concepts in 3D Tiles and designed to help integrate 3D Tiles into runtime engines.

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -15,7 +15,7 @@
 
 **Selected Articles**
    * [Millimeter Precision Point Clouds with Cesium and 3D Tiles](https://cesium.com/blog/2018/06/27/millimeter-precision-point-clouds/). June 2018
-   * [OneSky Using Cesium / 3D Tiles For Volumetric Airspace Visualization](https://onesky.blog/2018/04/16/onesky-using-cesium-3dtiles-for-volumetric-airspace-visualization/). April 2018.
+   * [OneSky Using Cesium / 3D Tiles For Volumetric Airspace Visualization](https://cesium.com/blog/2018/04/13/onesky-3dtiles/). April 2018.
    * [Cesium's Participation in OGC Testbed 13](https://cesium.com/blog/2018/02/06/citygml-testbed-13/). February 2018.
    * [Aerometrex and 3D Tiles](https://cesium.com/blog/2017/07/26/aerometrex-melbourne/). July 2017.
    * [Skipping Levels of Detail](https://cesium.com/blog/2017/05/05/skipping-levels-of-detail/). May 2017.

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -19,7 +19,7 @@
    * [Cesium's Participation in OGC Testbed 13](https://cesium.com/blog/2018/02/06/citygml-testbed-13/). February 2018.
    * [Aerometrex and 3D Tiles](https://cesium.com/blog/2017/07/26/aerometrex-melbourne/). July 2017.
    * [Skipping Levels of Detail](https://cesium.com/blog/2017/05/05/skipping-levels-of-detail/). May 2017.
-   * [Infrastructure Visualisation using 3D Tiles](http://www.sitesee.com.au/news/3dtiles). April 2017.
+   * [Infrastructure Visualisation using 3D Tiles](https://cesium.com/blog/2017/04/12/site-see-3d-tiles/). April 2017.
    * [Optimizing Spatial Subdivisions in Practice](https://cesium.com/blog/2017/04/04/spatial-subdivision-in-practice/). April 2017.
    * [Optimizing Subdivisions in Spatial Data Structures](https://cesium.com/blog/2017/03/30/spatial-subdivision/). March 2017.
    * [What's new in 3D Tiles?](https://cesium.com/blog/2017/03/29/whats-new-in-3d-tiles/) March 2017.

--- a/next/RESOURCES.md
+++ b/next/RESOURCES.md
@@ -29,7 +29,7 @@
 
 **Implementations**
   * [CesiumJS](https://github.com/CesiumGS/cesium) added experimental support for 3D Tiles Next features in version 1.87.1 ([Release Notes](https://github.com/CesiumGS/cesium/blob/main/CHANGES.md#1871---2021-11-09))
-  * [cesium-native](https://github.com/CesiumGS/cesium-native/issues/386) is in progress of adding 3D Tiles Next support ([Open pull request](https://github.com/CesiumGS/cesium-native/issues/386))
+  * [cesium-native](https://github.com/CesiumGS/cesium-native) is in progress of adding 3D Tiles Next support ([Open pull request](https://github.com/CesiumGS/cesium-native/issues/386))
 
 **Projects**
   * [minimal-pointcloud-gltf](https://github.com/wallabyway/minimal-pointcloud-gltf). A proposal for a standard point cloud representation in glTF and 3D Tiles Next

--- a/next/RESOURCES.md
+++ b/next/RESOURCES.md
@@ -29,7 +29,7 @@
 
 **Implementations**
   * [CesiumJS](https://github.com/CesiumGS/cesium) added experimental support for 3D Tiles Next features in version 1.87.1 ([Release Notes](https://github.com/CesiumGS/cesium/blob/main/CHANGES.md#1871---2021-11-09))
-  * [cesium-native](https://github.com/CesiumGS/cesium-native) is in progress of adding 3D Tiles Next support ([Open pull request](https://github.com/CesiumGS/cesium-native/issues/386))
+  * [cesium-native](https://github.com/CesiumGS/cesium-native) is in progress of adding 3D Tiles Next support ([Roadmap issue](https://github.com/CesiumGS/cesium-native/issues/386))
 
 **Projects**
   * [minimal-pointcloud-gltf](https://github.com/wallabyway/minimal-pointcloud-gltf). A proposal for a standard point cloud representation in glTF and 3D Tiles Next

--- a/next/RESOURCES.md
+++ b/next/RESOURCES.md
@@ -1,0 +1,35 @@
+## 3D Tiles Next Resources
+
+**Introduction**
+
+* [**Introducing 3D Tiles Next, Streaming Geospatial to the Metaverse**](https://cesium.com/blog/2021/11/10/introducing-3d-tiles-next/) - the announcement of the publication of the 3D Tiles Next specification, summarizing the technical goals and application areas
+* [**3D Tiles Next Reference Card**](./3d-tiles-next-reference-card.pdf) - a guide to learning about the new concepts that have been introduced with 3D Tiles Next
+
+**General Developer Resources**
+
+* [The 3D Tiles Next section](.) - the section in the 3D Tiles repository that contains an overview, resources, and specifications of all components related to 3D Tiles Next:
+  * [3D Metadata Specification](../specification/Metadata)
+  * [`3DTILES_metadata`](../extensions/3DTILES_metadata)
+  * [`EXT_mesh_features`](https://github.com/KhronosGroup/glTF/pull/2082) (glTF extension)
+  * [`3DTILES_implicit_tiling`](../extensions/3DTILES_implicit_tiling)
+  * [`3DTILES_bounding_volume_S2`](../extensions/3DTILES_bounding_volume_S2)
+  * [`3DTILES_multiple_contents`](../extensions/3DTILES_multiple_contents)
+  * [`3DTILES_content_gltf`](../extensions/3DTILES_content_gltf)
+
+**Demos**
+  * Demos that have been published based on the experimental 3D Tiles Next support in the [CesiumJS 1.87.1 Release:](https://github.com/CesiumGS/cesium/blob/main/CHANGES.md#1871---2021-11-09)
+    * [Photogrammetry Classification Demo](https://demos.cesium.com/ferry-building)
+    * [Property Textures Demo](https://demos.cesium.com/property-textures)
+    * [S2 Base Globe Demo](https://demos.cesium.com/owt-globe)
+    * [CDB Yemen Demo](https://demos.cesium.com/cdb-yemen)
+
+
+**Selected Talks**
+  * _Introducing 3D Tiles Next_, at Web3D Conference 2021. [Video and slides](https://cesium.com/learn/presentations/#web3d-conference-2021)
+
+**Implementations**
+  * [CesiumJS](https://github.com/CesiumGS/cesium) added experimental support for 3D Tiles Next features in version 1.87.1 ([Release Notes](https://github.com/CesiumGS/cesium/blob/main/CHANGES.md#1871---2021-11-09))
+  * [cesium-native](https://github.com/CesiumGS/cesium-native/issues/386) is in progress of adding 3D Tiles Next support ([Open pull request](https://github.com/CesiumGS/cesium-native/issues/386))
+
+**Projects**
+  * [minimal-pointcloud-gltf](https://github.com/wallabyway/minimal-pointcloud-gltf). A proposal for a standard point cloud representation in glTF and 3D Tiles Next


### PR DESCRIPTION
This addresses https://github.com/CesiumGS/3d-tiles/issues/560 . It adds the `next/RESOURCES.md` file that for now mainly contains the links from the blog post and the initial issue, but will be extended as new resources show up.

Preview: https://github.com/javagl/3d-tiles/blob/add-developer-resources/next/RESOURCES.md

