### PR TITLE
Disallow external tilesets inside implicit tiling or multiple contents

### DIFF
--- a/extensions/3DTILES_implicit_tiling/README.md
+++ b/extensions/3DTILES_implicit_tiling/README.md
@@ -122,6 +122,7 @@ The `3DTILES_implicit_tiling` extension may be defined on any tile in the tilese
 ```
 The `content` of an implicit tile must not have an associated `boundingVolume` property, but the [`3DTILES_metadata`](../3DTILES_metadata#implicit-tile-metadata) extension still allows defining bounding volumes for the content of implicit tiles. The possible [Semantics](../../specification/Metadata/Semantics) of the metadata include semantics like [`CONTENT_BOUNDING_BOX`](../../specification/Metadata/Semantics#content-semantics) that can be used to associate bounding volumes with the content of implicit tiles, for all tiles that are available in the implicit tree.  
 
+The `content.uri` may not point to an [external tileset](../../../specification#external-tilesets).
 
 In the extension object of the tile, the following properties about the implicit root tile are included:
 

--- a/extensions/3DTILES_multiple_contents/README.md
+++ b/extensions/3DTILES_multiple_contents/README.md
@@ -86,7 +86,9 @@ A `tile` may be extended with the `3DTILES_multiple_contents` extension object, 
 }
 ```
 
-When this extension is used the tile's `content` property must be omitted.
+When this extension is used the tile's `content` property must be omitted. 
+
+For any of the contents in the `3DTILES_multiple_contents` extension, the `uri` property may not point to an [external tileset](../../../specification#external-tilesets).
 
 ### Metadata Groups
 


### PR DESCRIPTION
External tilesets add quite a bit of complexity when implementing `3DTILES_implicit_tiling` and `3DTILES_multiple_contents`. In the CesiumJS implementation we disallowed these cases, but it looks like they never made it to the spec.

@lilleyse could you review?