### PR TITLE
Enforce no empty children arrays

### DIFF
--- a/specification/schema/tile.schema.json
+++ b/specification/schema/tile.schema.json
@@ -74,7 +74,8 @@
             "items": {
                 "$ref": "tile.schema.json"
             },
-            "uniqueItems": true
+            "uniqueItems": true,
+            "minItems": 1
         },
         "extensions": {},
         "extras": {}


### PR DESCRIPTION
This PR just adds `minItems: 1` to the `tile.children` property to enforce the requirement that leaf tiles may not have an empty `children` array, it's better to leave this undefined to avoid an additional `if` check for the array length.

To be clear, this detail was already in the schema description, this just allows the schema to enforce it automatically.

@lilleyse 