### PR TITLE
Renamed tile.content to content

### DIFF
--- a/extensions/3DTILES_multiple_contents/schema/tile.3DTILES_multiple_contents.schema.json
+++ b/extensions/3DTILES_multiple_contents/schema/tile.3DTILES_multiple_contents.schema.json
@@ -14,7 +14,7 @@
             "type": "array",
             "description": "An array of contents.",
             "items": {
-                "$ref": "tile.content.schema.json"
+                "$ref": "content.schema.json"
             },
             "minItems": 1
         },

--- a/specification/schema/content.schema.json
+++ b/specification/schema/content.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "tile.content.schema.json",
+    "$id": "content.schema.json",
     "title": "Content",
     "type": "object",
     "description": "Metadata about the tile's content and a link to the content.",

--- a/specification/schema/tile.schema.json
+++ b/specification/schema/tile.schema.json
@@ -66,7 +66,7 @@
         },
         "content": {
             "description": "Metadata about the tile's content and a link to the content. When this is omitted the tile is just used for culling.",
-            "$ref": "tile.content.schema.json"
+            "$ref": "content.schema.json"
         },
         "children": {
             "type": "array",


### PR DESCRIPTION
This was done in https://github.com/CesiumGS/3d-tiles/commit/7379ffde3ccb9e3b5e54e63631f77ea0c9e8fa16 but lost while merging 3d-tiles-next into the main branch.

There are still some plain _textual_ appearances of `tile.content`, but these are used as a "path description inside JSON", and do not explicitly refer to the schema file or a "type name".

