### PR TITLE
Implicit tiling schema tweaks

### DIFF
--- a/extensions/3DTILES_implicit_tiling/schema/subtree/availability.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/subtree/availability.schema.json
@@ -6,7 +6,7 @@
     "description": "An object describing the availability of a set of elements.",
     "allOf": [
         {
-            "$ref": "tilesetProperty.schema.json"
+            "$ref": "subtreeProperty.schema.json"
         }
     ],
     "properties": {

--- a/extensions/3DTILES_implicit_tiling/schema/subtree/availability.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/subtree/availability.schema.json
@@ -24,10 +24,14 @@
             "description": "Integer indicating whether all of the elements are available (1) or all are unavailable (0).",
             "anyOf": [
                 {
-                    "const": 0
+                    "const": 0,
+                    "description": "UNAVAILABLE",
+                    "type": "integer"
                 },
                 {
-                    "const": 1
+                    "const": 1,
+                    "description": "AVAILABLE",
+                    "type": "integer"
                 },
                 {
                     "type": "integer"

--- a/extensions/3DTILES_implicit_tiling/schema/subtree/buffer.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/subtree/buffer.schema.json
@@ -6,7 +6,7 @@
     "description": "A buffer is a binary blob. It is either the binary chunk of the subtree file, or an external buffer referenced by a URI.",
     "allOf": [
         {
-            "$ref": "tilesetProperty.schema.json"
+            "$ref": "subtreeProperty.schema.json"
         }
     ],
     "properties": {

--- a/extensions/3DTILES_implicit_tiling/schema/subtree/bufferView.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/subtree/bufferView.schema.json
@@ -6,7 +6,7 @@
     "description": "A contiguous subset of a buffer",
     "allOf": [
         {
-            "$ref": "tilesetProperty.schema.json"
+            "$ref": "subtreeProperty.schema.json"
         }
     ],
     "properties": {

--- a/extensions/3DTILES_implicit_tiling/schema/subtree/extension.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/subtree/extension.schema.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "extension.schema.json",
+    "title": "Extension",
+    "type": "object",
+    "description": "Dictionary object with extension-specific objects.",
+    "properties": {},
+    "additionalProperties": {
+        "type": "object"
+    }
+}

--- a/extensions/3DTILES_implicit_tiling/schema/subtree/extras.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/subtree/extras.schema.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "extras.schema.json",
+    "title": "Extras",
+    "description": "Application-specific data."
+}

--- a/extensions/3DTILES_implicit_tiling/schema/subtree/subtree.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/subtree/subtree.schema.json
@@ -6,7 +6,7 @@
     "description": "An object describing the availability of tiles and content in a subtree, as well as availability of children subtrees.",
     "allOf": [
         {
-            "$ref": "tilesetProperty.schema.json"
+            "$ref": "subtreeProperty.schema.json"
         }
     ],
     "properties": {

--- a/extensions/3DTILES_implicit_tiling/schema/subtree/subtreeProperty.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/subtree/subtreeProperty.schema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "subtreeProperty.schema.json",
+    "title": "Subtree Property",
+    "type": "object",
+    "properties": {
+        "extensions": {
+            "$ref": "extension.schema.json"
+        },
+        "extras": {
+            "$ref": "extras.schema.json"
+        }
+    }
+}

--- a/extensions/3DTILES_implicit_tiling/schema/tile.3DTILES_implicit_tiling.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/tile.3DTILES_implicit_tiling.schema.json
@@ -37,7 +37,7 @@
         "subtrees": {
             "allOf": [
                 {
-                    "$ref": "tile.3DTILES_implicit_tiling.subtree.schema.json"
+                    "$ref": "tile.3DTILES_implicit_tiling.subtrees.schema.json"
                 }
             ],
             "description": "An object describing the location of subtree files."

--- a/extensions/3DTILES_implicit_tiling/schema/tile.3DTILES_implicit_tiling.subtrees.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/tile.3DTILES_implicit_tiling.subtrees.schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "tile.3DTILES_implicit_tiling.subtree.schema.json",
-    "title": "Subtree",
+    "$id": "tile.3DTILES_implicit_tiling.subtrees.schema.json",
+    "title": "Subtrees",
     "type": "object",
     "description": "An object describing the location of subtree files.",
     "allOf": [


### PR DESCRIPTION
Fixed up some issues in the implicit tiling schema so that classes can be autogenerated correctly in cesium-native.

* The subtree format no longer references `tilesetProperty.schema.json` from 3D Tiles since this dependency was causing issues in cesium-native, and conceptually they are different file formats. Now `tilesetProperty.schema.json`, `extension.schema.jas`, and `extra.schema.json` have been duplicated for the subtree format. `tilesetProperty.schema.json` is now called `subtreeProperty.schema.json`
* Renamed `tile.3DTILES_implicit_tiling.subtree.schema.json` to `tile.3DTILES_implicit_tiling.subtrees.schema.json` (plural) to match the name of the property. Also changed the title to match. Now there aren't two titles called "Subtree".
* Added descriptions and types to the `constant` enum values.