### PR TITLE
Fix links for JSON Format

### DIFF
--- a/extensions/3DTILES_metadata/README.md
+++ b/extensions/3DTILES_metadata/README.md
@@ -338,7 +338,7 @@ Most property values are encoded as JSON within the entity to which they are ass
 
 Properties assigned to tilesets provide metadata about the tileset as a whole. Common examples might include year of collection, author details, or other general context for the tileset contents.
 
-The `tileset` object within a tileset's `3DTILES_metadata` extension must specify its class (`class`). Within a `properties` dictionary, values for properties are given, encoded as JSON types according to the [JSON Table Format](../../specification/Metadata/README.md#json-table-format) specification.
+The `tileset` object within a tileset's `3DTILES_metadata` extension must specify its class (`class`). Within a `properties` dictionary, values for properties are given, encoded as JSON types according to the [JSON Format](../../specification/Metadata/README.md#json-format) specification.
 
 > **Example:** The example below defines properties of a tileset, with the tileset representing an instance of a "city" class. Required properties "dateFounded" and "population" are given; optional property "country" is omitted.
 >
@@ -377,7 +377,7 @@ The `tileset` object within a tileset's `3DTILES_metadata` extension must specif
 
 Property values may be assigned to individual tiles, including (for example) spatial hints to optimize traversal algorithms. The example below uses the built-in semantic `TILE_MAXIMUM_HEIGHT` from the [3D Metadata Semantic Reference](../../specification/Metadata/Semantics).
 
-A `3DTILES_metadata` extension on a tile object must specify its class (`class`). Within a `properties` dictionary, values for properties are given, encoded as JSON types according to the [JSON Table Format](../../specification/Metadata/README.md#json-table-format) specification.
+A `3DTILES_metadata` extension on a tile object must specify its class (`class`). Within a `properties` dictionary, values for properties are given, encoded as JSON types according to the [JSON Format](../../specification/Metadata/README.md#json-format) specification.
 
 > **Example:**
 >
@@ -492,7 +492,7 @@ Tiles may contain more than one content entity (see: [`3DTILES_multiple_contents
 
 Tile contents are assigned to groups, representing collections of content, by attaching a `3DTILES_metadata` extension to the content object and specifying its `group` property. Each content entity may be assigned only to a single group, but a single group may have any number of tile contents assigned to it.
 
-The tileset's root `3DTILES_metadata` extension must define a list of available groups, if any, under its `groups` property. Each group definition must specify its class (`class`). Within a `properties` dictionary, values for properties are given, encoded as JSON types according to the [JSON Table Format](../../specification/Metadata/README.md#json-table-format) specification.
+The tileset's root `3DTILES_metadata` extension must define a list of available groups, if any, under its `groups` property. Each group definition must specify its class (`class`). Within a `properties` dictionary, values for properties are given, encoded as JSON types according to the [JSON Format](../../specification/Metadata/README.md#json-format) specification.
 
 > **Example:** The example below defines a custom "layer" class, where each of its two groups ("buildings" and "trees") are instances of the "layer" class associated with different "name", "color", and "priority" property values. The root tile defines two contents using `3DTILES_multiple_contents`, one content item belonging to each group.
 >


### PR DESCRIPTION
The links pointed to `JSON Table Format` where they should point to `JSON Format` instead.
