### PR TITLE
Add componentType to binary body reference markdown

### DIFF
--- a/specification/TileFormats/Batched3DModel/README.md
+++ b/specification/TileFormats/Batched3DModel/README.md
@@ -225,6 +225,7 @@ An object defining the reference to a section of the binary body of the features
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**byteOffset**|`number`|The offset into the buffer in bytes.| :white_check_mark: Yes|
+|**componentType**|`string`|The datatype of components in the property. The implicit component type of some semantics may be overridden using this property.| No|
 
 Additional properties are allowed.
 
@@ -236,6 +237,21 @@ The offset into the buffer in bytes.
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
+#### BinaryBodyReference.componentType
+
+The datatype of components in the property.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+   * `"BYTE"`
+   * `"UNSIGNED_BYTE"`
+   * `"SHORT"`
+   * `"UNSIGNED_SHORT"`
+   * `"INT"`
+   * `"UNSIGNED_INT"`
+   * `"FLOAT"`
+   * `"DOUBLE"`
 
 
 ---------------------------------------

--- a/specification/TileFormats/FeatureTable/README.md
+++ b/specification/TileFormats/FeatureTable/README.md
@@ -123,6 +123,7 @@ An object defining the reference to a section of the binary body of the features
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**byteOffset**|`number`|The offset into the buffer in bytes.| :white_check_mark: Yes|
+|**componentType**|`string`|The datatype of components in the property. Some tile formats specify semantics where the implicit component type can be overridden using this property.| No|
 
 Additional properties are allowed.
 
@@ -134,6 +135,21 @@ The offset into the buffer in bytes.
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
+#### BinaryBodyReference.componentType
+
+The datatype of components in the property.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+   * `"BYTE"`
+   * `"UNSIGNED_BYTE"`
+   * `"SHORT"`
+   * `"UNSIGNED_SHORT"`
+   * `"INT"`
+   * `"UNSIGNED_INT"`
+   * `"FLOAT"`
+   * `"DOUBLE"`
 
 
 ---------------------------------------

--- a/specification/TileFormats/Instanced3DModel/README.md
+++ b/specification/TileFormats/Instanced3DModel/README.md
@@ -431,6 +431,7 @@ An object defining the reference to a section of the binary body of the features
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**byteOffset**|`number`|The offset into the buffer in bytes.| :white_check_mark: Yes|
+|**componentType**|`string`|The datatype of components in the property. The implicit component type of some semantics may be overridden using this property.| No|
 
 Additional properties are allowed.
 
@@ -441,6 +442,23 @@ The offset into the buffer in bytes.
 * **Type**: `number`
 * **Required**: Yes
 * **Minimum**: ` >= 0`
+
+#### BinaryBodyReference.componentType
+
+The datatype of components in the property.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+   * `"BYTE"`
+   * `"UNSIGNED_BYTE"`
+   * `"SHORT"`
+   * `"UNSIGNED_SHORT"`
+   * `"INT"`
+   * `"UNSIGNED_INT"`
+   * `"FLOAT"`
+   * `"DOUBLE"`
+
 
 ---------------------------------------
 <a name="reference-globalpropertycartesian3"></a>

--- a/specification/TileFormats/PointCloud/README.md
+++ b/specification/TileFormats/PointCloud/README.md
@@ -510,6 +510,7 @@ An object defining the reference to a section of the binary body of the features
 |   |Type|Description|Required|
 |---|----|-----------|--------|
 |**byteOffset**|`number`|The offset into the buffer in bytes.| :white_check_mark: Yes|
+|**componentType**|`string`|The datatype of components in the property. The implicit component type of some semantics may be overridden using this property.| No|
 
 Additional properties are allowed.
 
@@ -521,6 +522,21 @@ The offset into the buffer in bytes.
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
+#### BinaryBodyReference.componentType
+
+The datatype of components in the property.
+
+* **Type**: `string`
+* **Required**: Yes
+* **Allowed values**:
+   * `"BYTE"`
+   * `"UNSIGNED_BYTE"`
+   * `"SHORT"`
+   * `"UNSIGNED_SHORT"`
+   * `"INT"`
+   * `"UNSIGNED_INT"`
+   * `"FLOAT"`
+   * `"DOUBLE"`
 
 
 ---------------------------------------


### PR DESCRIPTION
The property reference in the Markdown did not contain the `componentType` for `BinaryBodyReference` for Feature Tables. It was added at some point to the schema, in https://github.com/CesiumGS/3d-tiles/blob/main/specification/schema/featureTable.schema.json#L32 , to _optionally_ override the _implicit_ component type that was defined in the semantics.

- [Preview from `FeatureTable`](https://github.com/javagl/3d-tiles/tree/add-component-type-property-reference/specification/TileFormats/FeatureTable#binarybodyreference)
- [Preview from `Batched3DModel`](https://github.com/javagl/3d-tiles/tree/add-component-type-property-reference/specification/TileFormats/Batched3DModel#reference-binarybodyreference) (all others are the same as that)

The change was the same for `Batched3DModel`, `Instanced3DModel` and `PointCloud`, and _nearly_ the same for `FeatureTable`. The only difference is the property table, which says

- For `FeatureTable`: *The datatype of components in the property. Some tile formats specify semantics where the implicit component type can be overridden using this property.*
- For all others: *The datatype of components in the property. The implicit component type of some semantics may be overridden using this property.*

----

Somewhat going beyond the scope of this PR (which was only supposed to fix the Markdown): 

The wording feels a bit awkward: It says "**some**" formats/semantics, but does not say which ones. And whether or not this sort of "overriding" is allowed is never made _explicit_ anywhere. The overridability is apparently only defined _implicitly_, by listing multiple component types in the tables - for example, the `BatchID` in `PointCloud`, which says

> | Semantic | Data Type | Description | Required |
> | --- | --- | --- | --- |
> | ... | ... | ... | ... |
> | `BATCH_ID` | `uint8`, `uint16` (default), or `uint32` | The `batchId` of the point that can be used to retrieve metadata from the > `Batch Table`. | :red_circle: No. |

(And ... I'm not sure whether it can be called an "example", because ... it seems to be the _only_ semantic where this is the case....)



