### PR TITLE
Make `properties` optional in schema

### DIFF
--- a/extensions/3DTILES_metadata/schema/3DTILES_implicit_tiling/subtree.3DTILES_metadata.schema.json
+++ b/extensions/3DTILES_metadata/schema/3DTILES_implicit_tiling/subtree.3DTILES_metadata.schema.json
@@ -26,7 +26,6 @@
         "extras": {}
     },
     "required": [
-        "class",
-        "properties"
+        "class"
     ]
 }

--- a/extensions/3DTILES_metadata/schema/metadataEntity.schema.json
+++ b/extensions/3DTILES_metadata/schema/metadataEntity.schema.json
@@ -54,7 +54,6 @@
         "extras": {}
     },
     "required": [
-        "class",
-        "properties"
+        "class"
     ]
 }


### PR DESCRIPTION
The `properties` field for tile metadata and subtree metadata should not be marked as required because there are valid cases where all properties may be omitted.

For example... a class with two optional properties:

```json
"classes": {
  "tile": {
    "properties": {
      "name": {
        "componentType": "STRING",
        "required": false
      },
      "id": {
        "componentType": "STRING",
        "required": false
      }
    }
  }
}
```

Some tiles may provide values, but other may not

```json
    "children": [
      {
        "extensions": {
          "3DTILES_metadata": {
            "class": "tile",
            "properties": {
              "name": "Tile A",
              "id": 0
            }
          }
        }
      },
      {
        "extensions": {
          "3DTILES_metadata": {
            "class": "tile"
          }
        }
      }
    ]
```

I opened a similar PR for [EXT_mesh_features](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_mesh_features): https://github.com/CesiumGS/glTF/pull/49