### PR TITLE
Added note about zeroing unused bits in bitstreams

### DIFF
--- a/specification/Metadata/README.md
+++ b/specification/Metadata/README.md
@@ -374,6 +374,8 @@ A numeric value may be encoded as 8-, 16-, 32-, or 64-bit types. Multiple numeri
 
 A boolean value is encoded as a single bit, either 0 (`false`) or 1 (`true`). Multiple boolean values are packed tightly in the same buffer. These buffers of tightly-packed bits are sometimes referred to as bitstreams.
 
+For a table with `N` rows, the buffer that stores these boolean values will consist of `ceil(N / 8)` bytes. When `N` is not divisible by 8, then the unused bits of the last byte of this buffer must be set to 0.
+
 > **Implementation note:** Example accessing a boolean value for entity ID `i`.
 >
 > ```js


### PR DESCRIPTION
This was brought up via slack and mentioned in https://github.com/CesiumGS/3d-tiles/issues/617 . It originally (only) referred to the [availability bitstreams of `3DTILES_implicit_tiling`](https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_implicit_tiling#availability-packing), but this section mainly links to the "Storage Formats --> Binary Table Format --> Booleans" section of the Metadata spec, so we thought that it could make sense to add this as a general requirement there:

https://github.com/CesiumGS/3d-tiles/blob/c0d63ec8cf36b4b5d75c0ac031ea9bc4d5a53ae9/specification/Metadata/README.md#booleans

(This ensures that two "data sets" that describe "the same data" are _bitwise equal_, by making sure that there are no random, unspecified bits contained in the data)


