### PR TITLE
Change maximumLevel to availableLevels in implicit tiling extension

### DIFF
--- a/extensions/3DTILES_bounding_volume_S2/README.md
+++ b/extensions/3DTILES_bounding_volume_S2/README.md
@@ -256,7 +256,7 @@ The following example illustrates usage of `3DTILES_bounding_volume_S2` with `3D
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 4,
-        "maximumLevel": 7,
+        "availableLevels": 8,
         "subtrees": {
           "uri": "subtrees/{level}/{x}/{y}.subtree"
         }

--- a/extensions/3DTILES_implicit_tiling/README.md
+++ b/extensions/3DTILES_implicit_tiling/README.md
@@ -49,6 +49,7 @@ This extension is required, meaning it must be placed in both the `extensionsUse
   - [Buffers and Buffer Views](#buffers-and-buffer-views)
   - [Availability Packing](#availability-packing)
 - [Glossary](#glossary)
+- [Revision History](#revision-history)
 - [Appendix A: Availability Indexing](#appendix-a-availability-indexing)
 
 ## Overview
@@ -110,7 +111,7 @@ The `3DTILES_implicit_tiling` extension may be defined on any tile in the tilese
     "extensions": {
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
-        "maximumLevel": 20,
+        "availableLevels": 21,
         "subtrees": {
           "uri": "subtrees/{level}/{x}/{y}.subtree"
         },
@@ -129,7 +130,7 @@ In the extension object of the tile, the following properties about the implicit
 | Property | Description |
 | ------ | ----------- |
 | `subdivisionScheme` | Either `QUADTREE` or `OCTREE`. See [Subdivision scheme](#subdivision-scheme). |
-| `maximumLevel` | Level of the deepest available tile in the tree. |
+| `availableLevels` | How many levels there in the tree containing available tiles. |
 | `subtrees` | Template URI for subtree files. See [Subtrees](#subtrees). |
 | `subtreeLevels` | How many levels there are in each subtree. |
 
@@ -418,6 +419,12 @@ Availability bitstreams are packed in binary using the format described in the [
 * **tileset** - A hierarchical collection of tiles.
 * **tileset JSON** - A JSON file describing a tileset, as defined in the [3D Tiles specification](../../specification#tileset-json).
 
+## Revision History
+
+* **Version 0.0.0** November 2021
+  * Initial draft
+* **Version 1.0.0** February, 2022
+  * Changed `maximumLevel` to `availableLevels` for consistency with `subtreeLevels`. Note that `maximumLevel` is an index whereas `availableLevels` is a length, so `availableLevels` is equivalent to `maximumLevel + 1`.
 
 ## Appendix A: Availability Indexing
 

--- a/extensions/3DTILES_implicit_tiling/schema/tile.3DTILES_implicit_tiling.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/tile.3DTILES_implicit_tiling.schema.json
@@ -26,13 +26,13 @@
         },
         "subtreeLevels": {
             "type": "integer",
-            "description": "The number of distinct levels in each subtree. For example, a quadtree with `subtreeLevels = 2` will have subtrees with 5 nodes (one root and 4 children)",
+            "description": "The number of distinct levels in each subtree. For example, a quadtree with `subtreeLevels = 2` will have subtrees with 5 nodes (one root and 4 children).",
             "minimum": 1
         },
-        "maximumLevel": {
+        "availableLevels": {
             "type": "integer",
-            "description": "The level of the deepest available tile. Levels are numbered from 0 starting at the tile with the `3DTILES_implicit_tiling` extension. This tile's children are at level 1, the children's children are at level 2, and so on.",
-            "minimum": 0
+            "description": "The numbers of the levels in the tree with available tiles.",
+            "minimum": 1
         },
         "subtrees": {
             "allOf": [
@@ -48,7 +48,7 @@
     "required": [
         "subdivisionScheme",
         "subtreeLevels",
-        "maximumLevel",
+        "availableLevels",
         "subtrees"
     ]
 }

--- a/extensions/3DTILES_multiple_contents/README.md
+++ b/extensions/3DTILES_multiple_contents/README.md
@@ -192,7 +192,7 @@ Example tileset JSON:
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 10,
-        "maximumLevel": 16,
+        "availableLevels": 17,
         "subtrees": {
           "uri": "subtrees/{level}/{x}/{y}.subtree"
         }
@@ -329,7 +329,7 @@ Example tileset JSON:
       "3DTILES_implicit_tiling": {
         "subdivisionScheme": "QUADTREE",
         "subtreeLevels": 10,
-        "maximumLevel": 16,
+        "availableLevels": 17,
         "subtrees": {
           "uri": "subtrees/{level}/{x}/{y}.subtree"
         }


### PR DESCRIPTION
This is targeting a staging branch where we'll be pushing revisions to the 3D Tiles Next extensions during the next couple of weeks as we prepare for 3D Tiles 1.1. The staging branch will be merged into main once everything stabilzes.

Changes `maximumLevel` to `availableLevels` for consistency with `subtreeLevels`. Note that `maximumLevel` is an index whereas `availableLevels` is a length, so `availableLevels` is equivalent to `maximumLevel + 1`.

See discussion in https://github.com/CesiumGS/3d-tiles/issues/617