### PR TITLE
Added dedicated identifiers section

### DIFF
--- a/extensions/3DTILES_metadata/README.md
+++ b/extensions/3DTILES_metadata/README.md
@@ -159,7 +159,7 @@ Schemas may be embedded in tilesets with the `schema` property, or referenced ex
 
 Template for entities. Classes provide a list of property definitions. Every entity must be associated with a class, and the entity's properties must conform to the class's property definitions. Entities whose properties conform to a class are considered instances of that class.
 
-Classes are defined as entries in the `schema.classes` dictionary, indexed by class ID. Class IDs must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+Classes are defined as entries in the `schema.classes` dictionary, indexed by class ID. Class IDs must be [identifiers](../../specification/Metadata/README.md#identifiers) as defined in the 3D Metadata Specification.
 
 ### Class Property
 
@@ -195,7 +195,7 @@ Allowed values for `componentType`:
 - `"FLOAT32"`
 - `"FLOAT64"`
 
-Class properties are defined as entries in the `class.properties` dictionary, indexed by property ID. Property IDs must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+Class properties are defined as entries in the `class.properties` dictionary, indexed by property ID. Property IDs must be [identifiers](../../specification/Metadata/README.md#identifiers) as defined in the 3D Metadata Specification.
 
 By default, properties do not have any inherent meaning. A property may be assigned a **semantic**, an identifier that describes a property's meaning, for higher-level type information, runtime behavior, or other interpretation. The list of built-in semantics can be found in the [3D Metadata Semantic Reference](../../specification/Metadata/Semantics). Tileset authors may define their own application- or domain-specific semantics separately, and should follow the naming conventions in the Semantic Reference.
 
@@ -237,7 +237,7 @@ By default, properties do not have any inherent meaning. A property may be assig
 
 Set of categorical types, defined as `(name, value)` pairs. Enum properties use an enum as their type.
 
-Enums are defined as entries in the `schema.enums` dictionary, indexed by enum ID. Enum IDs must be alphanumeric identifiers matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+Enums are defined as entries in the `schema.enums` dictionary, indexed by enum ID. Enum IDs must be [identifiers](../../specification/Metadata/README.md#identifiers) as defined in the 3D Metadata Specification.
 
 > **Example:** A "quality" enum defining quality level of data within a tile. An "Unspecified" enum value is optional, but when provided as the `noData` value for a property (see: [3D Metadata → No Data Values](../../specification/Metadata#required-properties-and-no-data-values)) may be helpful to identify missing data.
 >

--- a/specification/Metadata/README.md
+++ b/specification/Metadata/README.md
@@ -104,6 +104,10 @@ This specification defines metadata schemas and methods for encoding metadata.
 
 Property values are stored with flexible representations to allow compact transmission and efficient lookups. This specification defines two possible [storage formats](#storage-formats).
 
+#### Identifiers
+
+Throughout this specification, IDs (identifiers) are strings that match the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`: Strings that consist of upper- or lowercase letters, digits, or underscores, starting with either a letter or an underscore. These strings should be camel case strings that are human-readable (wherever possible). When IDs subject to these restrictions are not sufficiently clear for human readers, applications should also provide a `name` for the structures that support dedicated names. 
+
 ## Schemas
 
 ### Schema
@@ -114,7 +118,7 @@ Components of a schema are listed below, and implementations may define addition
 
 #### ID
 
-IDs (`id`) uniquely identify a schema, and must be an alphanumeric identifier matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`. IDs should be camel case strings that are human-readable (wherever possible). When IDs subject to these restrictions are not sufficiently clear for human readers, applications should also provide a `name`.
+IDs (`id`) are unique [identifiers](#identifiers) for a schema.
 
 #### Version
 
@@ -162,7 +166,7 @@ An enum consists of a set of named values, represented as `(string, integer)` pa
 
 #### ID
 
-IDs (`id`) uniquely identify an enum within a schema, and must be an alphanumeric identifier matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`. IDs should be camel case strings that are human-readable (wherever possible). When IDs subject to these restrictions are not sufficiently clear for human readers, applications should also provide a `name`.
+IDs (`id`) are unique [identifiers](#identifiers) for an enum within a schema.
 
 #### Name
 
@@ -184,7 +188,7 @@ Classes represent categories of similar entities, and are defined by a collectio
 
 #### ID
 
-IDs (`id`) uniquely identify a class within a schema, and must be an alphanumeric identifier matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`. IDs should be camel case strings that are human-readable (wherever possible). When IDs subject to these restrictions are not sufficiently clear for human readers, applications should also provide a `name`.
+IDs (`id`) are unique [identifiers](#identifiers) for a class within a schema.
 
 #### Name
 
@@ -224,7 +228,7 @@ Properties describe the type and structure of values that may be associated with
 
 #### ID
 
-IDs (`id`) uniquely identify a property within a class, and must be an alphanumeric identifier matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`. IDs should be camel case strings that are human-readable (wherever possible). When IDs subject to these restrictions are not sufficiently clear for human readers, applications should also provide a `name`.
+IDs (`id`) are unique [identifiers](#identifiers) for a property within a class.
 
 #### Name
 


### PR DESCRIPTION
Moved the part that defines alphanumeric identifiers into an own section, on top of https://github.com/CesiumGS/3d-tiles/pull/646

The section itself is at https://github.com/javagl/3d-tiles/tree/alphanumeric-clarification-section/specification/Metadata#identifiers (Note: It is not added to the TOC - it mainly serves as an anchor to link to it explicitly). Directly below that is an example of its usage, in `Schema -> ID`. 

The `3DTILES_metadata` has also be updated (where it mentioned IDs), to point to this section, e.g. as in https://github.com/javagl/3d-tiles/tree/alphanumeric-clarification-section/extensions/3DTILES_metadata#class 


