### PR TITLE
Changed top-level groups from dictionary to array

### DIFF
--- a/extensions/3DTILES_metadata/README.md
+++ b/extensions/3DTILES_metadata/README.md
@@ -481,9 +481,9 @@ Metadata assigned to implicit tiles is stored in a more compact binary form. See
 
 Tiles may contain more than one content (see: [`3DTILES_multiple_contents`](../3DTILES_multiple_contents)), or multiple tiles may reference content sharing the same metadata. In these cases, metadata assigned to the tile would be inadequate or inefficient for describing tile contents. This extension allows content to be organized into collections, or "groups", and metadata may be associated with each group. Groups are useful for supporting metadata on only a subset of a tile's content, or for working with collections of contents as layers, e.g. to manage visibility or visual styling.
 
-Tile contents are assigned to groups, representing collections of content, by attaching a `3DTILES_metadata` extension to the content object and specifying its `group` property. Each content entity may be assigned only to a single group, but a single group may have any number of tile contents assigned to it.
+The tileset's root `3DTILES_metadata` extension must define a list of available groups, if any, under its `groups` property. Each group definition must specify its class (`class`) and an identifier (`id`) that uniquely identifies this group in the tileset. Within a `properties` dictionary, values for properties are given, encoded as JSON types according to the [JSON Format](../../specification/Metadata/README.md#json-format) specification.
 
-The tileset's root `3DTILES_metadata` extension must define a list of available groups, if any, under its `groups` property. Each group definition must specify its class (`class`). Within a `properties` dictionary, values for properties are given, encoded as JSON types according to the [JSON Format](../../specification/Metadata/README.md#json-format) specification.
+Tile contents are assigned to groups, representing collections of content, by attaching a `3DTILES_metadata` extension to the content object and specifying its `group` property to be the index of the group in the list of groups that was defined for the tileset. Each content entity may be assigned only to a single group, but a single group may have any number of tile contents assigned to it.
 
 > **Example:** The example below defines a custom "layer" class, where each of its two groups ("buildings" and "trees") are instances of the "layer" class associated with different "name", "color", and "priority" property values. The root tile defines two contents using `3DTILES_multiple_contents`, one content item belonging to each group.
 >
@@ -512,8 +512,9 @@ The tileset's root `3DTILES_metadata` extension must define a list of available 
 >           }
 >         }
 >       },
->       "groups": {
->         "buildings": {
+>       "groups": [
+>         {
+>           "id": "buildings",
 >           "class": "layer",
 >           "properties": {
 >             "name": "Buildings Layer",
@@ -521,7 +522,8 @@ The tileset's root `3DTILES_metadata` extension must define a list of available 
 >             "priority": 0
 >           }
 >         },
->         "trees": {
+>         {
+>           "id": "trees",
 >           "class": "layer",
 >           "properties": {
 >             "name": "Trees Layer",
@@ -529,7 +531,7 @@ The tileset's root `3DTILES_metadata` extension must define a list of available 
 >             "priority": 1
 >           }
 >         }
->       }
+>       ]
 >     }
 >   },
 >   "root": {
@@ -538,11 +540,11 @@ The tileset's root `3DTILES_metadata` extension must define a list of available 
 >         "content": [
 >           {
 >             "uri": "buildings.glb",
->             "extensions": {"3DTILES_metadata": {"group": "buildings"}}
+>             "extensions": {"3DTILES_metadata": {"group": 0 }}
 >           },
 >           {
 >             "uri": "trees.glb",
->             "extensions": {"3DTILES_metadata": {"group": "trees"}}
+>             "extensions": {"3DTILES_metadata": {"group": 1 }}
 >           }
 >         ]
 >       }

--- a/extensions/3DTILES_metadata/schema/content.3DTILES_metadata.schema.json
+++ b/extensions/3DTILES_metadata/schema/content.3DTILES_metadata.schema.json
@@ -11,8 +11,8 @@
     ],
     "properties": {
         "group": {
-            "type": "string",
-            "description": "The group this content belongs to. The value must correspond to a group ID declared in the `groups` dictionary."
+            "type": "integer",
+            "description": "The group this content belongs to. The value is an index into the array of `groups` that is defined for the containing tileset."
         },
         "class": {},
         "properties": {},

--- a/extensions/3DTILES_metadata/schema/group.schema.json
+++ b/extensions/3DTILES_metadata/schema/group.schema.json
@@ -10,9 +10,22 @@
         }
     ],
     "properties": {
+        "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Unique identifier for the group."
+        },
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The name of the group, e.g. for display purposes."
+        },
         "class": {},
         "properties": {},
         "extensions": {},
         "extras": {}
-    }
+    },
+    "required": [
+        "id"
+    ]
 }

--- a/extensions/3DTILES_metadata/schema/tileset.3DTILES_metadata.schema.json
+++ b/extensions/3DTILES_metadata/schema/tileset.3DTILES_metadata.schema.json
@@ -32,12 +32,12 @@
             "description": "An object containing statistics about entities."
         },
         "groups": {
-            "type": "object",
-            "description": "A dictionary, where each key is a group ID and each value is an object defining the group. Group IDs may contain only alphanumeric and underscore characters",
-            "minProperties": 1,
-            "additionalProperties": {
+            "type": "array",
+            "description": "An array of groups.",
+            "items": {
                 "$ref": "group.schema.json"
-            }
+            },
+            "minItems": 1
         },
         "tileset": {
             "allOf": [


### PR DESCRIPTION
As one result from https://github.com/CesiumGS/3d-tiles/issues/637 , the top level `groups` (that are defined for the tileset) should not be a dictionary, but an array, where each group has a unique identifier.
 
