### PR TITLE
Disallow default and noData if required is true

### DIFF
--- a/extensions/3DTILES_metadata/schema/class.property.schema.json
+++ b/extensions/3DTILES_metadata/schema/class.property.schema.json
@@ -158,7 +158,7 @@
                     "$ref": "definitions.schema.json#/definitions/noDataValue"
                 }
             ],
-            "description": "A `noData` value represents missing data — also known as a sentinel value — wherever it appears. `BOOLEAN` properties may not specify `noData` values. This is given as the plain property value, without the transforms from the `normalized`, `offset`, and `scale` properties."
+            "description": "A `noData` value represents missing data — also known as a sentinel value — wherever it appears. `BOOLEAN` properties may not specify `noData` values. This is given as the plain property value, without the transforms from the `normalized`, `offset`, and `scale` properties. Must not be defined if `required` is true."
         },
         "default": {
             "allOf": [
@@ -166,7 +166,7 @@
                     "$ref": "definitions.schema.json#/definitions/anyValue"
                 }
             ],
-            "description": "A default value to use when encountering a `noData` value or an omitted property. The value is given in its final form, taking the effect of `normalized`, `offset`, and `scale` properties into account."
+            "description": "A default value to use when encountering a `noData` value or an omitted property. The value is given in its final form, taking the effect of `normalized`, `offset`, and `scale` properties into account. Must not be defined if `required` is true."
         },
         "semantic": {
             "type": "string",


### PR DESCRIPTION
This came up in a recent CesiumJS PR: https://github.com/CesiumGS/cesium/pull/10172#discussion_r821151177.

`default` and `noData` must not be defined if `required` is true.

Once this is merged I'll update `EXT_structural_metadata`