### PR TITLE
Update extensions for 3D Tiles 1.1

### DIFF
--- a/extensions/3DTILES_batch_table_hierarchy/README.md
+++ b/extensions/3DTILES_batch_table_hierarchy/README.md
@@ -1,19 +1,38 @@
+### ⚠️ `3DTILES_batch_table_hierarchy` was deprecated in 3D Tiles 1.1. See https://github.com/CesiumGS/3d-tiles/issues/558 for discussion about hierarchical metadata. ⚠️
+
+<!-- omit in toc -->
 # 3DTILES_batch_table_hierarchy Extension
 
+<!-- omit in toc -->
 ## Contributors
 
 * Sean Lilley, [@lilleyse](https://github.com/lilleyse)
 * Patrick Cozzi, [@pjcozzi](https://twitter.com/pjcozzi)
 
+<!-- omit in toc -->
+## Status
+
+Complete
+
+<!-- omit in toc -->
+## Dependencies
+
+Written against the 3D Tiles 1.0 and 1.1 specifications.
+
+<!-- omit in toc -->
+## Optional vs. Required
+
+This extension is optional, meaning it should be placed in the `extensionsUsed` list, but not in the `extensionsRequired` list.
+
 ## Contents
 
-* [Overview](#overview)
-* [Motivation](#motivation)
-* [Batch table JSON schema updates](#batch-table-json-schema-updates)
-   * [3DTILES_batch_table_hierarchy](#3dtiles_batch_table_hierarchy)
-* [Examples](#examples)
-* [Styling](#styling)
-* [Notes](#notes)
+- [Contents](#contents)
+- [Overview](#overview)
+- [Motivation](#motivation)
+- [Batch table JSON schema updates](#batch-table-json-schema-updates)
+- [Examples](#examples)
+- [Styling](#styling)
+- [Notes](#notes)
 
 ## Overview
 
@@ -152,6 +171,7 @@ Sample Batch Table:
 }
 ```
 
+<!-- omit in toc -->
 ### 3DTILES_batch_table_hierarchy
 
 `classes` is an array of objects, where each object contains the following properties:
@@ -192,6 +212,7 @@ JSON schema definitions can be found in [3DTILES_batch_table_hierarchy.schema.js
 
 ## Examples
 
+<!-- omit in toc -->
 ### Feature classes
 
 Going back to the example of a parking lot with car, lamp post, and tree features, a Batch Table might look like this:
@@ -250,6 +271,7 @@ Batch Table Hierarchy, parking lot:
 
 ![batch table hierarchy parking lot](figures/batch-table-hierarchy-parking-lot.png)
 
+<!-- omit in toc -->
 ### Feature hierarchy
 
 The city block example would now look like this:
@@ -344,6 +366,7 @@ This extension supports additional built-in functions in the styling language fo
 * [`isExactClass`](#isexactclass)
 * [`isClass`](#isclass)
 
+<!-- omit in toc -->
 ### getExactClassName
 
 ```
@@ -370,6 +393,7 @@ For example, the following style will color all doorknobs yellow, all doors gree
 }
 ```
 
+<!-- omit in toc -->
 ### isExactClass
 
 ```
@@ -389,6 +413,7 @@ For example, the following style will color all doors, but not features that are
 }
 ```
 
+<!-- omit in toc -->
 ### isClass
 
 ```

--- a/extensions/3DTILES_bounding_volume_S2/README.md
+++ b/extensions/3DTILES_bounding_volume_S2/README.md
@@ -12,7 +12,7 @@
 <!-- omit in toc -->
 ## Status
 
-Draft
+Complete
 
 <!-- omit in toc -->
 ## Dependencies

--- a/extensions/3DTILES_content_gltf/README.md
+++ b/extensions/3DTILES_content_gltf/README.md
@@ -1,3 +1,5 @@
+### ⚠️ `3DTILES_content_gltf` has been promoted to core in 3D Tiles 1.1. See [glTF Tile Format](../../specification/TileFormats/glTF/). ⚠️
+
 # 3DTILES_content_gltf
 
 ## Contributors
@@ -10,7 +12,7 @@
 
 ## Status
 
-Draft
+Complete
 
 ## Dependencies
 

--- a/extensions/3DTILES_draco_point_compression/README.md
+++ b/extensions/3DTILES_draco_point_compression/README.md
@@ -1,8 +1,22 @@
+### ⚠️ `3DTILES_draco_point_compression` was deprecated in 3D Tiles 1.1. See [`pnts` migration guide](../../specification/TileFormats/glTF/#point-cloud-pnts). ⚠️
+
 # 3DTILES_draco_point_compression Extension
 
 ## Contributors
 
 * Sean Lilley, [@lilleyse](https://github.com/lilleyse)
+
+## Status
+
+Complete
+
+## Dependencies
+
+Written against the 3D Tiles 1.0 specification.
+
+## Optional vs. Required
+
+This extension is required, meaning it must be placed in both the `extensionsUsed` and `extensionsRequired` lists in the tileset JSON.
 
 ## Contents
 
@@ -151,6 +165,7 @@ _This section is non-normative._
 
 ---------------------------------------
 <a name="reference-3dtiles_draco_point_compression-feature-table-extension"></a>
+<!-- omit in toc -->
 ## 3DTILES_draco_point_compression Feature Table extension
 
 Specifies the compressed Feature Table properties and the location of the compressed data in the Feature Table binary.
@@ -163,6 +178,7 @@ Specifies the compressed Feature Table properties and the location of the compre
 |**byteOffset**|`number`|A zero-based offset relative to the start of the Feature Table binary at which the compressed data starts.| :white_check_mark: Yes|
 |**byteLength**|`number`|The length, in bytes, of the compressed data.| :white_check_mark: Yes|
 
+<!-- omit in toc -->
 ### properties :white_check_mark:
 
 Defines the properties stored in the compressed data. Each property is associated with a unique ID. This ID is used to identify the property within
@@ -172,6 +188,7 @@ the compressed data. No two properties in the Feature Table and Batch Table may 
 * **Required**: Yes
 * **Type of each property**: `number`
 
+<!-- omit in toc -->
 ### byteOffset :white_check_mark:
 
 A zero-based offset relative to the start of the Feature Table binary at which the compressed data starts.
@@ -180,6 +197,7 @@ A zero-based offset relative to the start of the Feature Table binary at which t
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
+<!-- omit in toc -->
 ### byteLength :white_check_mark:
 
 The length, in bytes, of the compressed data.
@@ -190,6 +208,7 @@ The length, in bytes, of the compressed data.
 
 ---------------------------------------
 <a name="reference-3dtiles_draco_point_compression-batch-table-extension"></a>
+<!-- omit in toc -->
 ## 3DTILES_draco_point_compression Batch Table extension
 
 Specifies the compressed Batch Table properties.
@@ -200,6 +219,7 @@ Specifies the compressed Batch Table properties.
 |---|----|-----------|--------|
 |**properties**|`object`|Defines the properties stored in the compressed data. Each property is associated with a unique ID. This ID is used to identify the property within the compressed data. No two properties in the Feature Table and Batch Table may use the same ID.| :white_check_mark: Yes|
 
+<!-- omit in toc -->
 ### properties :white_check_mark:
 
 Defines the properties stored in the compressed data. Each property is associated with a unique ID. This ID is used to identify the property within the compressed data. No two properties in the Feature Table and Batch Table may use the same ID.

--- a/extensions/3DTILES_implicit_tiling/README.md
+++ b/extensions/3DTILES_implicit_tiling/README.md
@@ -1,3 +1,5 @@
+### ⚠️ `3DTILES_implicit_tiling` has been promoted to core in 3D Tiles 1.1. See [Implicit Tiling](../../specification/ImplicitTiling/). ⚠️
+
 <!-- omit in toc -->
 # 3DTILES_implicit_tiling
 
@@ -18,7 +20,7 @@
 <!-- omit in toc -->
 ## Status
 
-Draft
+Complete
 
 <!-- omit in toc -->
 ## Dependencies

--- a/extensions/3DTILES_metadata/README.md
+++ b/extensions/3DTILES_metadata/README.md
@@ -1,3 +1,5 @@
+### ⚠️ `3DTILES_metadata` has been promoted to core in 3D Tiles 1.1. See [Metadata](../../specification/Metadata/). ⚠️
+
 <!-- omit in toc -->
 # 3DTILES_metadata Extension
 
@@ -15,7 +17,7 @@
 <!-- omit in toc -->
 ## Status
 
-Draft
+Complete
 
 <!-- omit in toc -->
 ## Dependencies

--- a/extensions/3DTILES_multiple_contents/README.md
+++ b/extensions/3DTILES_multiple_contents/README.md
@@ -1,3 +1,5 @@
+### ⚠️ `3DTILES_multiple_contents` has been promoted to core in 3D Tiles 1.1. See [Multiple Contents](../../specification/#multiple-contents). ⚠️
+
 # 3DTILES_multiple_contents
 
 ## Contributors
@@ -11,7 +13,7 @@
 
 ## Status
 
-Draft
+Complete
 
 ## Dependencies
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -2,20 +2,23 @@
 
 ## Extensions
 
-### 3D Tiles Next
+### Extensions for 3D Tiles 1.1
 
-3D Tiles Next is a collection of draft extensions to advance 3D Tiles. It provides extensions for cleaner integration with the glTF ecosystem, rich semantic metadata, and efficient spatial indexes for scalable simulations. See the [3D Tiles Next](../next) page for more details.
+Extension|Notes
+--|--
+[3DTILES_bounding_volume_S2](./3DTILES_bounding_volume_S2)|_Written against 3D Tiles 1.1 and 1.0_
 
-* [3DTILES_content_gltf](./3DTILES_content_gltf)
-* [3DTILES_multiple_contents](./3DTILES_multiple_contents)
-* [3DTILES_metadata](./3DTILES_metadata)
-* [3DTILES_implicit_tiling](./3DTILES_implicit_tiling)
-* [3DTILES_bounding_volume_S2](./3DTILES_bounding_volume_S2)
+### Extensions for 3D Tiles 1.0
 
-### Other
-
-* [3DTILES_batch_table_hierarchy](./3DTILES_batch_table_hierarchy/)
-* [3DTILES_draco_point_compression](./3DTILES_draco_point_compression/)
+Extension|Notes
+--|--
+[3DTILES_content_gltf](./3DTILES_content_gltf)|_Promoted to core in 3D Tiles 1.1_
+[3DTILES_multiple_contents](./3DTILES_multiple_contents)|_Promoted to core in 3D Tiles 1.1_
+[3DTILES_metadata](./3DTILES_metadata)|_Promoted to core in 3D Tiles 1.1_
+[3DTILES_implicit_tiling](./3DTILES_implicit_tiling)|_Promoted to core in 3D Tiles 1.1_
+[3DTILES_bounding_volume_S2](./3DTILES_bounding_volume_S2)|_Written against 3D Tiles 1.1 and 1.0_
+[3DTILES_batch_table_hierarchy](./3DTILES_batch_table_hierarchy/)|_Deprecated in 3D Tiles 1.1_
+[3DTILES_draco_point_compression](./3DTILES_draco_point_compression/)|_Deprecated in 3D Tiles 1.1_
 
 ## About
 

--- a/specification/TileFormats/BatchTable/README.md
+++ b/specification/TileFormats/BatchTable/README.md
@@ -1,3 +1,5 @@
+### ⚠️ Batch Table was deprecated in 3D Tiles 1.1. See [glTF migration guide](../glTF/#appendix-a-migration-from-legacy-tile-formats). ⚠️
+
 # Batch Table
 
 ## Contents

--- a/specification/TileFormats/Batched3DModel/README.md
+++ b/specification/TileFormats/Batched3DModel/README.md
@@ -1,3 +1,5 @@
+### ⚠️ Batched 3D Model was deprecated in 3D Tiles 1.1. See [`b3dm` migration guide](../glTF/#batched-3d-model-b3dm). ⚠️
+
 # Batched 3D Model
 
 ## Contents

--- a/specification/TileFormats/Composite/README.md
+++ b/specification/TileFormats/Composite/README.md
@@ -1,14 +1,18 @@
+### ⚠️ Composite was deprecated in 3D Tiles 1.1. See [`cpmt` migration guide](../glTF/#composite-cmpt). ⚠️
+
+<!-- omit in toc -->
 # Composite
 
+<!-- omit in toc -->
 ## Contents
 
-* [Overview](#overview)
-* [Layout](#layout)
-    * [Padding](#padding)
-* [Header](#header)
-* [Inner tiles](#inner-tiles)
-* [File extension and MIME type](#file-extension-and-mime-type)
-* [Implementation examples](#implementation-examples)
+- [Overview](#overview)
+- [Layout](#layout)
+  - [Padding](#padding)
+- [Header](#header)
+- [Inner tiles](#inner-tiles)
+- [File extension and MIME type](#file-extension-and-mime-type)
+- [Implementation examples](#implementation-examples)
 
 ## Overview
 

--- a/specification/TileFormats/FeatureTable/README.md
+++ b/specification/TileFormats/FeatureTable/README.md
@@ -1,3 +1,5 @@
+### ⚠️ Feature Table was deprecated in 3D Tiles 1.1. See [glTF migration guide](../glTF/#appendix-a-migration-from-legacy-tile-formats). ⚠️
+
 # Feature Table
 
 ## Contents

--- a/specification/TileFormats/Instanced3DModel/README.md
+++ b/specification/TileFormats/Instanced3DModel/README.md
@@ -1,3 +1,5 @@
+### ⚠️ Instanced 3D Model was deprecated in 3D Tiles 1.1. See [`i3dm` migration guide](../glTF/#instanced-3d-model-i3dm). ⚠️
+
 # Instanced 3D Model
 
 ## Contents

--- a/specification/TileFormats/PointCloud/README.md
+++ b/specification/TileFormats/PointCloud/README.md
@@ -1,34 +1,38 @@
+### ⚠️ Point Cloud was deprecated in 3D Tiles 1.1. See [`pnts` migration guide](../glTF/#point-cloud-pnts). ⚠️
+
+<!-- omit in toc -->
 # Point Cloud
 
+<!-- omit in toc -->
 ## Contents
 
-* [Overview](#overview)
-* [Layout](#layout)
-    * [Padding](#padding)
-* [Header](#header)
-* [Feature Table](#feature-table)
-    * [Semantics](#semantics)
-        * [Point semantics](#point-semantics)
-        * [Global semantics](#global-semantics)
-    * [Point positions](#point-positions)
-        * [Coordinate reference system (CRS)](#coordinate-reference-system-crs)
-        * [RTC_CENTER](#rtc_center)
-        * [Quantized positions](#quantized-positions)
-    * [Point colors](#point-colors)
-    * [Point normals](#point-normals)
-        * [Oct-encoded normal vectors](#oct-encoded-normal-vectors)
-    * [Batched points](#batched-points)
-    * [Examples](#examples)
-        * [Positions only](#positions-only)
-        * [Positions and colors](#positions-and-colors)
-        * [Quantized positions and oct-encoded normals](#quantized-positions-and-oct-encoded-normals)
-        * [Batched points](#batched-points)
-        * [Per-point properties](#per-point-properties)
-* [Batch Table](#batch-table)
-* [Extensions](#extensions)
-* [File extension and MIME type](#file-extension-and-mime-type)
-* [Implementation example](#implementation-example)
-* [Property reference](#property-reference)
+- [Overview](#overview)
+- [Layout](#layout)
+  - [Padding](#padding)
+- [Header](#header)
+- [Feature Table](#feature-table)
+  - [Semantics](#semantics)
+    - [Point semantics](#point-semantics)
+    - [Global semantics](#global-semantics)
+  - [Point positions](#point-positions)
+    - [Coordinate reference system (CRS)](#coordinate-reference-system-crs)
+    - [RTC_CENTER](#rtc_center)
+    - [Quantized positions](#quantized-positions)
+  - [Point colors](#point-colors)
+  - [Point normals](#point-normals)
+    - [Oct-encoded normal vectors](#oct-encoded-normal-vectors)
+  - [Batched points](#batched-points)
+  - [Examples](#examples)
+    - [Positions only](#positions-only)
+    - [Positions and colors](#positions-and-colors)
+    - [Quantized positions and oct-encoded normals](#quantized-positions-and-oct-encoded-normals)
+    - [Batched points](#batched-points-1)
+    - [Per-point properties](#per-point-properties)
+- [Batch Table](#batch-table)
+- [Extensions](#extensions)
+- [File extension and MIME type](#file-extension-and-mime-type)
+- [Implementation example](#implementation-example)
+- [Property reference](#property-reference)
 
 ## Overview
 
@@ -357,6 +361,7 @@ Code for reading the header can be found in [`PointCloud3DModelTileContent.js`](
 
 ---------------------------------------
 <a name="reference-point-cloud-feature-table"></a>
+<!-- omit in toc -->
 ### Point Cloud Feature Table
 
 A set of Point Cloud semantics that contains values defining the position and appearance properties for points in a tile.
@@ -385,6 +390,7 @@ A set of Point Cloud semantics that contains values defining the position and ap
 Additional properties are allowed.
 
 * **Type of each property**: [`Property`](#reference-property)
+<!-- omit in toc -->
 #### PointCloudFeatureTable.extensions
 
 Dictionary object with extension-specific objects.
@@ -393,13 +399,14 @@ Dictionary object with extension-specific objects.
 * **Required**: No
 * **Type of each property**: Extension
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.extras
 
 Application-specific data.
 
 * **Type**: `any`
 * **Required**: No
-
+<!-- omit in toc -->
 #### PointCloudFeatureTable.POSITION
 
 A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -407,6 +414,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 * **Type**: `object`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.POSITION_QUANTIZED
 
 A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -414,6 +422,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 * **Type**: `object`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.RGBA
 
 A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -421,6 +430,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 * **Type**: `object`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.RGB
 
 A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -428,6 +438,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 * **Type**: `object`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.RGB565
 
 A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -435,6 +446,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 * **Type**: `object`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.NORMAL
 
 A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -442,6 +454,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 * **Type**: `object`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.NORMAL_OCT16P
 
 A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -449,6 +462,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 * **Type**: `object`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.BATCH_ID
 
 A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -456,6 +470,7 @@ A [`BinaryBodyReference`](#reference-binarybodyreference) object defining the re
 * **Type**: `object`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.POINTS_LENGTH :white_check_mark:
 
 A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -463,6 +478,7 @@ A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an
 * **Type**: `object`, `number` `[1]`, `number`
 * **Required**: Yes
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.RTC_CENTER
 
 A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -470,6 +486,7 @@ A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defin
 * **Type**: `object`, `number` `[3]`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.QUANTIZED_VOLUME_OFFSET
 
 A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -477,6 +494,7 @@ A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defin
 * **Type**: `object`, `number` `[3]`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.QUANTIZED_VOLUME_SCALE
 
 A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -484,6 +502,7 @@ A [`GlobalPropertyCartesian3`](#reference-globalpropertycartesian3) object defin
 * **Type**: `object`, `number` `[3]`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.CONSTANT_RGBA
 
 A [`GlobalPropertyCartesian4`](#reference-globalpropertycartesian4) object defining a 4-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -491,6 +510,7 @@ A [`GlobalPropertyCartesian4`](#reference-globalpropertycartesian4) object defin
 * **Type**: `object`, `number` `[4]`
 * **Required**: No
 
+<!-- omit in toc -->
 #### PointCloudFeatureTable.BATCH_LENGTH
 
 A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).
@@ -501,6 +521,7 @@ A [`GlobalPropertyInteger`](#reference-globalpropertyinteger) object defining an
 
 ---------------------------------------
 <a name="reference-binarybodyreference"></a>
+<!-- omit in toc -->
 ### BinaryBodyReference
 
 An object defining the reference to a section of the binary body of the features table where the property values are stored if not defined directly in the JSON.
@@ -514,6 +535,7 @@ An object defining the reference to a section of the binary body of the features
 
 Additional properties are allowed.
 
+<!-- omit in toc -->
 #### BinaryBodyReference.byteOffset :white_check_mark:
 
 The offset into the buffer in bytes.
@@ -522,6 +544,7 @@ The offset into the buffer in bytes.
 * **Required**: Yes
 * **Minimum**: ` >= 0`
 
+<!-- omit in toc -->
 #### BinaryBodyReference.componentType
 
 The datatype of components in the property.
@@ -541,6 +564,7 @@ The datatype of components in the property.
 
 ---------------------------------------
 <a name="reference-globalpropertycartesian3"></a>
+<!-- omit in toc -->
 ### GlobalPropertyCartesian3
 
 An object defining a global 3-component numeric property value for all features.
@@ -551,6 +575,7 @@ An object defining a global 3-component numeric property value for all features.
 
 ---------------------------------------
 <a name="reference-globalpropertycartesian4"></a>
+<!-- omit in toc -->
 ### GlobalPropertyCartesian4
 
 An object defining a global 4-component numeric property value for all features.
@@ -561,6 +586,7 @@ An object defining a global 4-component numeric property value for all features.
 
 ---------------------------------------
 <a name="reference-globalpropertyinteger"></a>
+<!-- omit in toc -->
 ### GlobalPropertyInteger
 
 An object defining a global integer property value for all features.
@@ -570,6 +596,7 @@ An object defining a global integer property value for all features.
 
 ---------------------------------------
 <a name="reference-property"></a>
+<!-- omit in toc -->
 ### Property
 
 A user-defined property which specifies per-feature application-specific metadata in a tile. Values either can be defined directly in the JSON as an array, or can refer to sections in the binary body with a [`BinaryBodyReference`](#reference-binarybodyreference) object.


### PR DESCRIPTION
Checks off several boxes in https://github.com/CesiumGS/3d-tiles/issues/651

* Added deprecation notices for `Batched 3D Model`, `Instanced 3D Model`, `Point Cloud`, `Composite`, `Batch Table`, `Feature Table`, `3DTILES_batch_table_hierarchy`, `3DTILES_draco_point_compression`. Pointed to the relevant sections of the glTF migration guide.
* Added "promoted to core in 3D Tiles 1.1" notices for `3DTILES_implicit_tiling`, `3DTILES_content_gltf`, `3DTILES_metadata`, and `3DTILES_multiple_contents`
* Marked extensions as "Complete"
* Updated `extensions/README`