### PR TITLE
Fix for requirements on schema and schemaUri

### DIFF
--- a/specification/schema/tileset.schema.json
+++ b/specification/schema/tileset.schema.json
@@ -94,22 +94,10 @@
         "geometricError",
         "root"
     ],
-    "oneOf": [
-        {
-            "description": "External schema, if any.",
-            "not": {
-                "required": [
-                    "schema"
-                ]
-            }
-        },
-        {
-            "description": "Internal schema, if any.",
-            "not": {
-                "required": [
-                    "schemaUri"
-                ]
-            }
-        }
-    ]
+    "not": {
+        "required": [
+            "schema",
+            "schemaUri"
+        ]
+    }
 }


### PR DESCRIPTION
They should be mutually exclusive, but it is also valid to have neither of them.