### PR TITLE
Fix for requirements on content and contents

### DIFF
--- a/specification/schema/tile.schema.json
+++ b/specification/schema/tile.schema.json
@@ -109,17 +109,10 @@
         "boundingVolume",
         "geometricError"
     ],
-    "oneOf": [
-        {
-            "required": [
-                "content"
-            ]
-        },
-        {
-            "required": [
-                "contents"
-            ]
-        },
-        {}
-    ]
+    "not": {
+        "required": [
+            "content",
+            "contents"
+        ]
+    }
 }


### PR DESCRIPTION
They should be mutually exclusive, but it is also valid to have neither of them.