### PR TITLE
Remove `group.id` property

### DIFF
--- a/extensions/3DTILES_metadata/schema/group.schema.json
+++ b/extensions/3DTILES_metadata/schema/group.schema.json
@@ -10,11 +10,6 @@
         }
     ],
     "properties": {
-        "id": {
-            "type": "string",
-            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
-            "description": "Unique identifier for the group within the tileset. This must be an alphanumeric identifier matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`."
-        },
         "class": {},
         "properties": {},
         "extensions": {},

--- a/specification/schema/group.schema.json
+++ b/specification/schema/group.schema.json
@@ -10,11 +10,6 @@
         }
     ],
     "properties": {
-        "id": {
-            "type": "string",
-            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
-            "description": "Unique identifier for the group within the tileset. This must be an alphanumeric identifier matching the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`."
-        },
         "class": {},
         "properties": {},
         "extensions": {},


### PR DESCRIPTION
Removes the `group.id` property so the groups are consistent with other metadata entities. Metadata entities such as tilesets, tiles, contents, and groups should use the [`ID`](https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/Metadata/Semantics#general-semantics) semantic.

There was some discussion about this in https://github.com/CesiumGS/3d-tiles/pull/648#pullrequestreview-900412973.