### PR TITLE
Removed links into repository from JSON schema files

### DIFF
--- a/extensions/3DTILES_implicit_tiling/schema/subtree/availability.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/subtree/availability.schema.json
@@ -6,7 +6,7 @@
     "description": "An object describing the availability of a set of elements.",
     "properties": {
         "bitstream": {
-            "description": "Index of a buffer view that indicates whether each element is available. The bitstream conforms to the boolean array encoding described in the [3D Metadata specification](../../specification/Metadata). If an element is available, its bit is 1, and if it is unavailable, its bit is 0.",
+            "description": "Index of a buffer view that indicates whether each element is available. The bitstream conforms to the boolean array encoding described in the 3D Metadata specification. If an element is available, its bit is 1, and if it is unavailable, its bit is 0.",
             "type": "integer",
             "minimum": 0
         },

--- a/specification/schema/Styling/style.booleanExpression.schema.json
+++ b/specification/schema/Styling/style.booleanExpression.schema.json
@@ -6,5 +6,5 @@
         "boolean",
         "string"
     ],
-    "description": "A boolean or string with a 3D Tiles style expression that evaluates to a boolean. See [Expressions](/specification/Styling/README.md#expressions)."
+    "description": "A boolean or string with a 3D Tiles style expression that evaluates to a boolean. Details are described in the 3D Tiles Styling specification."
 }

--- a/specification/schema/Styling/style.colorExpression.schema.json
+++ b/specification/schema/Styling/style.colorExpression.schema.json
@@ -3,5 +3,5 @@
     "$id": "style.colorExpression.schema.json",
     "title": "Color Expression",
     "type": "string",
-    "description": "3D Tiles style `expression` that evaluates to a Color. See [Expressions](/specification/Styling/README.md#expressions)."
+    "description": "3D Tiles style `expression` that evaluates to a Color. Details are described in the 3D Tiles Styling specification."
 }

--- a/specification/schema/Styling/style.expression.schema.json
+++ b/specification/schema/Styling/style.expression.schema.json
@@ -3,5 +3,5 @@
     "$id": "style.expression.schema.json",
     "title": "Expression",
     "type": "string",
-    "description": "A valid 3D Tiles style expression. See [Expressions](/specification/Styling/README.md#expressions)."
+    "description": "A valid 3D Tiles style expression. Details are described in the 3D Tiles Styling specification."
 }

--- a/specification/schema/Styling/style.numberExpression.schema.json
+++ b/specification/schema/Styling/style.numberExpression.schema.json
@@ -6,5 +6,5 @@
         "number",
         "string"
     ],
-    "description": "3D Tiles style expression that evaluates to a number. See [Expressions](/specification/Styling/README.md#expressions)."
+    "description": "3D Tiles style expression that evaluates to a number. Details are described in the 3D Tiles Styling specification."
 }

--- a/specification/schema/TileFormats/b3dm.featureTable.schema.json
+++ b/specification/schema/TileFormats/b3dm.featureTable.schema.json
@@ -8,11 +8,11 @@
     "properties": {
         "BATCH_LENGTH": {
             "$ref": "featureTable.schema.json#/definitions/globalPropertyInteger",
-            "description": "A `GlobalPropertyInteger` object defining an integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics)."
+            "description": "A `GlobalPropertyInteger` object defining an integer property for all features. Details about this property are described in the 3D Tiles specification."
         },
         "RTC_CENTER": {
             "$ref": "featureTable.schema.json#/definitions/globalPropertyCartesian3",
-            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Batched3DModel/README.md#semantics)."
+            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. Details about this property are described in the 3D Tiles specification."
         }
     },
     "required": [

--- a/specification/schema/TileFormats/i3dm.featureTable.schema.json
+++ b/specification/schema/TileFormats/i3dm.featureTable.schema.json
@@ -7,59 +7,59 @@
     "deprecated": true,
     "properties": {
         "POSITION": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "POSITION_QUANTIZED": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "NORMAL_UP": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "NORMAL_RIGHT": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "NORMAL_UP_OCT32P": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "NORMAL_RIGHT_OCT32P": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "SCALE": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "SCALE_NON_UNIFORM": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "BATCH_ID": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "INSTANCES_LENGTH": {
-            "description": "A `GlobalPropertyInteger` object defining an integer property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `GlobalPropertyInteger` object defining an integer property for all features. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/globalPropertyInteger"
         },
         "RTC_CENTER": {
-            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/globalPropertyCartesian3"
         },
         "QUANTIZED_VOLUME_OFFSET": {
-            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/globalPropertyCartesian3"
         },
         "QUANTIZED_VOLUME_SCALE": {
-            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all features. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/globalPropertyCartesian3"
         },
         "EAST_NORTH_UP": {
-            "description": "A `GlobalPropertyBoolean` object defining a boolean property for all features. See the corresponding property semantic in [Semantics](/specification/TileFormats/Instanced3DModel/README.md#semantics).",
+            "description": "A `GlobalPropertyBoolean` object defining a boolean property for all features. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/globalPropertyBoolean"
         }
     },

--- a/specification/schema/TileFormats/pnts.featureTable.schema.json
+++ b/specification/schema/TileFormats/pnts.featureTable.schema.json
@@ -7,59 +7,59 @@
     "deprecated": true,
     "properties": {
         "POSITION": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "POSITION_QUANTIZED": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "RGBA": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "RGB": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "RGB565": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "NORMAL": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "NORMAL_OCT16P": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "BATCH_ID": {
-            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `BinaryBodyReference` object defining the reference to a section of the binary body where the property values are stored. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/binaryBodyReference"
         },
         "POINTS_LENGTH": {
-            "description": "A `GlobalPropertyInteger` object defining an integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `GlobalPropertyInteger` object defining an integer property for all points. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/globalPropertyInteger"
         },
         "RTC_CENTER": {
-            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all points. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/globalPropertyCartesian3"
         },
         "QUANTIZED_VOLUME_OFFSET": {
-            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all points. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/globalPropertyCartesian3"
         },
         "QUANTIZED_VOLUME_SCALE": {
-            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `GlobalPropertyCartesian3` object defining a 3-component numeric property for all points. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/globalPropertyCartesian3"
         },
         "CONSTANT_RGBA": {
-            "description": "A `GlobalPropertyCartesian4` object defining a 4-component numeric property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `GlobalPropertyCartesian4` object defining a 4-component numeric property for all points. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/globalPropertyCartesian4"
         },
         "BATCH_LENGTH": {
-            "description": "A `GlobalPropertyInteger` object defining an integer property for all points. See the corresponding property semantic in [Semantics](/specification/TileFormats/PointCloud/README.md#semantics).",
+            "description": "A `GlobalPropertyInteger` object defining an integer property for all points. Details about this property are described in the 3D Tiles specification.",
             "$ref": "featureTable.schema.json#/definitions/globalPropertyInteger"
         }
     },


### PR DESCRIPTION
As mentioned in https://github.com/CesiumGS/3d-tiles/issues/590#issuecomment-1103181075 : 

There had been several places in the JSON schema files that linked to markdown files in the repository, using relative paths (e.g. in [`style.booleanExpression.schema.json`](https://github.com/CesiumGS/3d-tiles/blob/40d8a8b3efc5046fd020a49569b1a5865aa3a426/specification/Styling/schema/style.booleanExpression.schema.json#L9), but several more)

These links cannot be stable, and they cannot be sensibly processed in many downstream pipelines (code generators, wetzel, AsciiDoc outputs...). So this PR replaces them with a short, verbal statement that just refers to the 3D Tiles specification. 

