### PR TITLE
Draft 1.1 external tileset class clarification

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -818,7 +818,7 @@ Although they are defined independently, the metadata structure in 3D Tiles and 
 
 The Metadata schema defines the structure of the metadata. It contains a definition of the metadata classes, which are templates for the metadata instances, and define the set of properties that each metadata instance has. The metadata schema is stored within a tileset in the form of a JSON representation according to the [Metadata Schema Reference Implementation](Metadata/ReferenceImplementation/Schema/README.md). This reference implementation includes the definition of the JSON schema for the metadata schema. 
 
-Schemas may be embedded in tilesets with the `schema` property, or referenced externally by the `schemaUri` property. Multiple tilesets and glTF contents may refer to the same schema to avoid duplication.
+Schemas may be embedded in tilesets with the `schema` property, or referenced externally by the `schemaUri` property. Multiple tilesets and glTF contents may refer to the same schema to avoid duplication. Any class that is defined in the schema of an [#external-tilesets](external tileset) must also be defined in the top-level tileset schema.
 
 > **Example:** Schema with a `building` class having three properties, "height", "owners", and "buildingType". The "buildingType" property refers to the `buildingType` enum as its data type, also defined in the schema. Later examples show how entities declare their class and supply values for their properties.
 >

--- a/specification/README.md
+++ b/specification/README.md
@@ -818,7 +818,7 @@ Although they are defined independently, the metadata structure in 3D Tiles and 
 
 The Metadata schema defines the structure of the metadata. It contains a definition of the metadata classes, which are templates for the metadata instances, and define the set of properties that each metadata instance has. The metadata schema is stored within a tileset in the form of a JSON representation according to the [Metadata Schema Reference Implementation](Metadata/ReferenceImplementation/Schema/README.md). This reference implementation includes the definition of the JSON schema for the metadata schema. 
 
-Schemas may be embedded in tilesets with the `schema` property, or referenced externally by the `schemaUri` property. Multiple tilesets and glTF contents may refer to the same schema to avoid duplication. Any class that is defined in the schema of an [#external-tilesets](external tileset) must also be defined in the top-level tileset schema.
+Schemas may be embedded in tilesets with the `schema` property, or referenced externally by the `schemaUri` property. Multiple tilesets and glTF contents may refer to the same schema to avoid duplication. Any class that is defined in the schema of an [external tileset](#external-tilesets) must also be defined in the top-level tileset schema.
 
 > **Example:** Schema with a `building` class having three properties, "height", "owners", and "buildingType". The "buildingType" property refers to the `buildingType` enum as its data type, also defined in the schema. Later examples show how entities declare their class and supply values for their properties.
 >


### PR DESCRIPTION
This only adds the hint

> Any class that is defined in the schema of an external tileset must also be defined in the top-level tileset schema.

in the main 'Metadata Schema' section, and thus, reflects the change from https://github.com/CesiumGS/cesium/pull/10387

If desired, the [schema description](https://github.com/CesiumGS/3d-tiles/blob/1c1b792c15f8f4c42a375d3822e78f5b57567259/specification/schema/metadataEntity.schema.json#L10) could also be extended by

> The class that property values conform to. The value must be a class ID declared in the `classes` dictionary of the metadata schema **of the *`<right>`* tileset** 

Where *`<right>`* could be "containing" or "root/top-level". 

<sup>There are some questions that could or should be investigated further, about namespacing or disambiguation (e.g. related to https://github.com/CesiumGS/cesium/issues/10085 ), but for now, this change is only an attempt to clarify the structure that is expected by CesiumJS</sup>




