### PR TITLE
Introduce BinaryBodyOffset as a defined type

### DIFF
--- a/specification/schema/TileFormats/featureTable.schema.json
+++ b/specification/schema/TileFormats/featureTable.schema.json
@@ -9,16 +9,26 @@
         "$ref": "#/definitions/property"
     },
     "definitions": {
-        "binaryBodyReference": {
-            "title": "BinaryBodyReference",
+        "binaryBodyOffset": {
+            "title": "BinaryBodyOffset",
             "$ref": "rootProperty.schema.json",
-            "description": "An object defining the reference to a section of the binary body of the features table where the property values are stored if not defined directly in the JSON.",
+            "description": "An object defining the offset into a section of the binary body of the features table where the property values are stored if not defined directly in the JSON.",
             "properties": {
                 "byteOffset": {
                     "type": "integer",
                     "description": "The offset into the buffer in bytes.",
                     "minimum": 0
-                },
+                }
+            },
+            "required": [
+                "byteOffset"
+            ]
+        },
+        "binaryBodyReference": {
+            "title": "BinaryBodyReference",
+            "$ref": "#/definitions/binaryBodyOffset",
+            "description": "An object defining the reference to a section of the binary body of the features table where the property values are stored if not defined directly in the JSON.",
+            "properties": {
                 "componentType": {
                     "description": "The datatype of components in the property. This is defined only if the semantic allows for overriding the implicit component type. These cases are specified in each tile format.",
                     "anyOf": [
@@ -51,10 +61,7 @@
                         }
                     ]
                 }
-            },
-            "required": [
-                "byteOffset"
-            ]
+            }
         },
         "property": {
             "title": "Property",
@@ -90,17 +97,7 @@
             "description": "An object defining a global integer property value for all features.",
             "oneOf": [
                 {
-                    "type": "object",
-                    "properties": {
-                        "byteOffset": {
-                            "type": "integer",
-                            "description": "The offset into the buffer in bytes.",
-                            "minimum": 0
-                        }
-                    },
-                    "required": [
-                        "byteOffset"
-                    ]
+                    "$ref": "#/definitions/binaryBodyOffset"
                 },
                 {
                     "type": "integer",
@@ -113,17 +110,7 @@
             "description": "An object defining a global numeric property value for all features.",
             "oneOf": [
                 {
-                    "type": "object",
-                    "properties": {
-                        "byteOffset": {
-                            "type": "integer",
-                            "description": "The offset into the buffer in bytes.",
-                            "minimum": 0
-                        }
-                    },
-                    "required": [
-                        "byteOffset"
-                    ]
+                    "$ref": "#/definitions/binaryBodyOffset"
                 },
                 {
                     "type": "number",
@@ -136,17 +123,7 @@
             "description": "An object defining a global 3-component numeric property values for all features.",
             "oneOf": [
                 {
-                    "$ref": "rootProperty.schema.json",
-                    "properties": {
-                        "byteOffset": {
-                            "type": "integer",
-                            "description": "The offset into the buffer in bytes.",
-                            "minimum": 0
-                        }
-                    },
-                    "required": [
-                        "byteOffset"
-                    ]
+                    "$ref": "#/definitions/binaryBodyOffset"
                 },
                 {
                     "type": "array",
@@ -163,17 +140,7 @@
             "description": "An object defining a global 4-component numeric property values for all features.",
             "oneOf": [
                 {
-                    "$ref": "rootProperty.schema.json",
-                    "properties": {
-                        "byteOffset": {
-                            "type": "integer",
-                            "description": "The offset into the buffer in bytes.",
-                            "minimum": 0
-                        }
-                    },
-                    "required": [
-                        "byteOffset"
-                    ]
+                    "$ref": "#/definitions/binaryBodyOffset"
                 },
                 {
                     "type": "array",


### PR DESCRIPTION
Certain [type definitions in `featureTable.schema.json`](https://github.com/CesiumGS/3d-tiles/blob/39ff902c75bd3620ac83e5327c40ea5b198e8315/specification/schema/TileFormats/featureTable.schema.json#L91) referred to multiple types with `oneOf`, where the first type did not have a name. In additon to causing trouble for generating the property reference with wetzel, this "unnamed type" was repeated several times. Now, this unnamed type is called `BinaryBodyOffset`.

---

Property reference before:
```
[#reference-featuretable-definitions-globalpropertyinteger]
=== featureTable#/definitions/globalPropertyInteger

An object defining a global integer property value for all features.

* **Type**: One of `object`, `integer`

* **Additional properties are allowed.**

```

Property reference after:
```
[#reference-featuretable-definitions-globalpropertyinteger]
=== featureTable-definitions-globalPropertyInteger

An object defining a global integer property value for all features.

* **Type**: One of <<reference-featuretable-definitions-binarybodyoffset,`featureTable-definitions-binaryBodyOffset`>>, `integer`

* **Additional properties are allowed.**
```
where the link leads to the definition...
```
[#reference-featuretable-definitions-binarybodyoffset]
=== featureTable-definitions-binaryBodyOffset

An object defining the offset into a section of the binary body of the features table where the property values are stored if not defined directly in the JSON.
...
```
The output is still not perfect. I'm playing "whack-a-mole" with wetzel right now. But this change should be independent of that, and at least _allow_ this sort of linking, instead of using `object`.

---

This seemed to be the only "unnamed type" for now. There are some properties that are still listed as `object`. Namely the ones where type constraints are established with `additionalProperties` -  for example, [`statistics.classes`](https://github.com/CesiumGS/3d-tiles/blob/39ff902c75bd3620ac83e5327c40ea5b198e8315/specification/schema/Statistics/statistics.schema.json#L8). One could make a case for giving this a name as well. But right now, these are documented with a line
```
    * **Type of each property**: <<reference-statistics-class,`statistics.class`>>
```
which should be fine here.

