### PR TITLE
Refer to "media type" instead of "MIME type"

### DIFF
--- a/specification/Styling/README.md
+++ b/specification/Styling/README.md
@@ -27,7 +27,7 @@
   - [Built-in functions](#built-in-functions)
   - [Notes](#notes)
 - [Point Cloud](#point-cloud)
-- [File extension and MIME type](#file-extension-and-mime-type)
+- [File extension and media type](#file-extension-and-media-type)
 - [Property reference](#property-reference)
 
 ## Overview
@@ -1291,9 +1291,9 @@ For example:
 > * Mismatched type comparisons (e.g. `1.0 === false`)
 > * Array index out of bounds
 
-## File extension and MIME type
+## File extension and media type
 
-Tileset styles use the `.json` extension and the `application/json` mime type.
+Tileset styles use the `.json` extension and the `application/json` media type.
 
 ## Property reference
 

--- a/specification/TileFormats/Batched3DModel/README.md
+++ b/specification/TileFormats/Batched3DModel/README.md
@@ -15,7 +15,7 @@
 * [Batch Table](#batch-table)
 * [Binary glTF](#binary-gltf)
    * [Coordinate system](#coordinate-system)
-* [File extension and MIME type](#file-extension-and-mime-type)
+* [File extension and media type](#file-extension-and-media-type)
 * [Implementation example](#implementation-example)
 * [Property reference](#property-reference)
 
@@ -149,9 +149,9 @@ Vertex positions may be defined relative-to-center for high-precision rendering,
 
 
 
-## File extension and MIME type
+## File extension and media type
 
-Batched 3D Model tiles use the `.b3dm` extension and `application/octet-stream` MIME type.
+Batched 3D Model tiles use the `.b3dm` extension and `application/octet-stream` media type.
 
 An explicit file extension is optional. Valid implementations may ignore it and identify a content's format by the `magic` field in its header.
 

--- a/specification/TileFormats/Composite/README.md
+++ b/specification/TileFormats/Composite/README.md
@@ -11,7 +11,7 @@
   - [Padding](#padding)
 - [Header](#header)
 - [Inner tiles](#inner-tiles)
-- [File extension and MIME type](#file-extension-and-mime-type)
+- [File extension and media type](#file-extension-and-media-type)
 - [Implementation examples](#implementation-examples)
 
 ## Overview
@@ -61,9 +61,9 @@ Inner tile fields are stored tightly packed immediately following the header sec
 
 Refer to the spec for each tile format for more details.
 
-## File extension and MIME type
+## File extension and media type
 
-Composite tiles use the `.cmpt` extension and `application/octet-stream` MIME type.
+Composite tiles use the `.cmpt` extension and `application/octet-stream` media type.
 
 An explicit file extension is optional. Valid implementations may ignore it and identify a content's format by the `magic` field in its header.
 

--- a/specification/TileFormats/Instanced3DModel/README.md
+++ b/specification/TileFormats/Instanced3DModel/README.md
@@ -25,7 +25,7 @@
 * [Batch Table](#batch-table)
 * [glTF](#gltf)
     * [Coordinate system](#coordinate-system)
-* [File extension and MIME type](#file-extension-and-mime-type)
+* [File extension and media type](#file-extension-and-media-type)
 * [Property reference](#property-reference)
 
 ## Overview
@@ -274,9 +274,9 @@ When the [`RTC_CENTER`](#rtc-center) is defined in the feature table of an Insta
 5. [Tile transform](../../README.md#tile-transforms)
 
 
-## File extension and MIME type
+## File extension and media type
 
-Instanced 3D models tiles use the `.i3dm` extension and `application/octet-stream` MIME type.
+Instanced 3D models tiles use the `.i3dm` extension and `application/octet-stream` media type.
 
 An explicit file extension is optional. Valid implementations may ignore it and identify a content's format by the `magic` field in its header.
 

--- a/specification/TileFormats/PointCloud/README.md
+++ b/specification/TileFormats/PointCloud/README.md
@@ -30,7 +30,7 @@
     - [Per-point properties](#per-point-properties)
 - [Batch Table](#batch-table)
 - [Extensions](#extensions)
-- [File extension and MIME type](#file-extension-and-mime-type)
+- [File extension and media type](#file-extension-and-media-type)
 - [Implementation example](#implementation-example)
 - [Property reference](#property-reference)
 
@@ -341,9 +341,9 @@ The following extensions can be applied to a Point Cloud tile.
 
 * [3DTILES_draco_point_compression](../../../extensions/3DTILES_draco_point_compression/)
 
-## File extension and MIME type
+## File extension and media type
 
-Point cloud tiles use the `.pnts` extension and `application/octet-stream` MIME type.
+Point cloud tiles use the `.pnts` extension and `application/octet-stream` media type.
 
 An explicit file extension is optional. Valid implementations may ignore it and identify a content's format by the `magic` field in its header.
 


### PR DESCRIPTION
This changes the use of "MIME type" to "media type" in the **draft-1.1** branch

This was brought up in https://github.com/CesiumGS/3d-tiles/pull/682#discussion_r883562983
