### PR TITLE
Refer to "media type" instead of "mime type"

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -41,7 +41,7 @@ Acknowledgements:
 ## Contents
 
 * [Introduction](#introduction)
-* [File extensions and MIME types](#file-extensions-and-mime-types)
+* [File extensions and media types](#file-extensions-and-media-types)
 * [JSON encoding](#json-encoding)
 * [URIs](#uris)
 * [Units](#units)
@@ -102,13 +102,13 @@ A tileset may use a 2D spatial tiling scheme similar to raster and vector tiling
 
 Optionally a [3D Tiles Style](./Styling/), or _style_, may be applied to a tileset. A style defines expressions to be evaluated which modify how each feature is displayed.
 
-## File extensions and MIME types
+## File extensions and media types
 
-3D Tiles uses the following file extensions and MIME types.
+3D Tiles uses the following file extensions and media types.
 
-* Tileset files use the `.json` extension and the `application/json` MIME type.
-* Tile content files use the file type and MIME format specific to their [tile format specification](#tile-format-specifications).
-* Tileset style files use the `.json` extension and the `application/json` MIME type.
+* Tileset files use the `.json` extension and the `application/json` media type.
+* Tile content files use the file type and media type specific to their [tile format specification](#tile-format-specifications).
+* Tileset style files use the `.json` extension and the `application/json` media type.
 
 Explicit file extensions are optional. Valid implementations may ignore it and identify a content's format by the `magic` field in its header.
 

--- a/specification/Styling/README.md
+++ b/specification/Styling/README.md
@@ -27,7 +27,7 @@
    * [Built-in functions](#built-in-functions)
    * [Notes](#notes)
 * [Point Cloud](#point-cloud)
-* [File extension and MIME type](#file-extension-and-mime-type)
+* [File extension and media type](#file-extension-and-media-type)
 * [Property reference](#property-reference)
 
 ## Overview
@@ -1255,9 +1255,9 @@ For example:
 > * Mismatched type comparisons (e.g. `1.0 === false`)
 > * Array index out of bounds
 
-## File extension and MIME type
+## File extension and media type
 
-Tileset styles use the `.json` extension and the `application/json` mime type.
+Tileset styles use the `.json` extension and the `application/json` media type.
 
 ## Property reference
 

--- a/specification/TileFormats/Batched3DModel/README.md
+++ b/specification/TileFormats/Batched3DModel/README.md
@@ -13,7 +13,7 @@
 * [Batch Table](#batch-table)
 * [Binary glTF](#binary-gltf)
    * [Coordinate system](#coordinate-system)
-* [File extension and MIME type](#file-extension-and-mime-type)
+* [File extension and media type](#file-extension-and-media-type)
 * [Implementation example](#implementation-example)
 * [Property reference](#property-reference)
 
@@ -140,9 +140,9 @@ By default embedded glTFs use a right handed coordinate system where the _y_-axi
 
 Vertex positions may be defined relative-to-center for high-precision rendering, see [Precisions, Precisions](http://help.agi.com/AGIComponents/html/BlogPrecisionsPrecisions.htm). If defined, `RTC_CENTER` specifies the center position that all vertex positions are relative to after the coordinate system transform and glTF node hierarchy transforms have been applied.
 
-## File extension and MIME type
+## File extension and media type
 
-Batched 3D Model tiles use the `.b3dm` extension and `application/octet-stream` MIME type.
+Batched 3D Model tiles use the `.b3dm` extension and `application/octet-stream` media type.
 
 An explicit file extension is optional. Valid implementations may ignore it and identify a content's format by the `magic` field in its header.
 

--- a/specification/TileFormats/Composite/README.md
+++ b/specification/TileFormats/Composite/README.md
@@ -7,7 +7,7 @@
     * [Padding](#padding)
 * [Header](#header)
 * [Inner tiles](#inner-tiles)
-* [File extension and MIME type](#file-extension-and-mime-type)
+* [File extension and media type](#file-extension-and-media-type)
 * [Implementation examples](#implementation-examples)
 
 ## Overview
@@ -57,9 +57,9 @@ Inner tile fields are stored tightly packed immediately following the header sec
 
 Refer to the spec for each tile format for more details.
 
-## File extension and MIME type
+## File extension and media type
 
-Composite tiles use the `.cmpt` extension and `application/octet-stream` MIME type.
+Composite tiles use the `.cmpt` extension and `application/octet-stream` media type.
 
 An explicit file extension is optional. Valid implementations may ignore it and identify a content's format by the `magic` field in its header.
 

--- a/specification/TileFormats/Instanced3DModel/README.md
+++ b/specification/TileFormats/Instanced3DModel/README.md
@@ -23,7 +23,7 @@
 * [Batch Table](#batch-table)
 * [glTF](#gltf)
     * [Coordinate system](#coordinate-system)
-* [File extension and MIME type](#file-extension-and-mime-type)
+* [File extension and media type](#file-extension-and-media-type)
 * [Property reference](#property-reference)
 
 ## Overview
@@ -261,9 +261,9 @@ When the glTF field contains a URI, then this URI may point to a [relative exter
 By default glTFs use a right handed coordinate system where the _y_-axis is up. For consistency with the _z_-up coordinate system of 3D Tiles, glTFs must be transformed at runtime. See [glTF transforms
 ](../../README.md#gltf-transforms) for more details.
 
-## File extension and MIME type
+## File extension and media type
 
-Instanced 3D models tiles use the `.i3dm` extension and `application/octet-stream` MIME type.
+Instanced 3D models tiles use the `.i3dm` extension and `application/octet-stream` media type.
 
 An explicit file extension is optional. Valid implementations may ignore it and identify a content's format by the `magic` field in its header.
 

--- a/specification/TileFormats/PointCloud/README.md
+++ b/specification/TileFormats/PointCloud/README.md
@@ -26,7 +26,7 @@
         * [Per-point properties](#per-point-properties)
 * [Batch Table](#batch-table)
 * [Extensions](#extensions)
-* [File extension and MIME type](#file-extension-and-mime-type)
+* [File extension and media type](#file-extension-and-media-type)
 * [Implementation example](#implementation-example)
 * [Property reference](#property-reference)
 
@@ -333,9 +333,9 @@ The following extensions can be applied to a Point Cloud tile.
 
 * [3DTILES_draco_point_compression](../../../extensions/3DTILES_draco_point_compression/)
 
-## File extension and MIME type
+## File extension and media type
 
-Point cloud tiles use the `.pnts` extension and `application/octet-stream` MIME type.
+Point cloud tiles use the `.pnts` extension and `application/octet-stream` media type.
 
 An explicit file extension is optional. Valid implementations may ignore it and identify a content's format by the `magic` field in its header.
 


### PR DESCRIPTION
This changes the use of "MIME type" to "media type" in the **main** branch

This was brought up in https://github.com/CesiumGS/3d-tiles/pull/682#discussion_r883562983

