### PR TITLE
Fix extension name in description in subtree schema

### DIFF
--- a/extensions/3DTILES_implicit_tiling/schema/subtree/subtree.schema.json
+++ b/extensions/3DTILES_implicit_tiling/schema/subtree/subtree.schema.json
@@ -57,7 +57,7 @@
                 "minimum": 0
             },
             "minItems": 1,
-            "description": "An array of indexes to property tables containing content metadata. If the tile has a single content this array will have one element; if the tile has multiple contents - as supported by EXT_multiple_contents and 3D Tiles 1.1 - this array will have multiple elements. Content metadata only exists for available contents and is tightly packed by increasing tile index. To access individual content metadata, implementations may create a mapping from tile indices to content metadata indices."
+            "description": "An array of indexes to property tables containing content metadata. If the tile has a single content this array will have one element; if the tile has multiple contents - as supported by 3DTILES_multiple_contents and 3D Tiles 1.1 - this array will have multiple elements. Content metadata only exists for available contents and is tightly packed by increasing tile index. To access individual content metadata, implementations may create a mapping from tile indices to content metadata indices."
         },
         "subtreeMetadata": {
             "$ref": "subtreeMetadata.schema.json",

--- a/specification/schema/Subtree/subtree.schema.json
+++ b/specification/schema/Subtree/subtree.schema.json
@@ -57,7 +57,7 @@
                 "minimum": 0
             },
             "minItems": 1,
-            "description": "An array of indexes to property tables containing content metadata. If the tile has a single content this array will have one element; if the tile has multiple contents - as supported by EXT_multiple_contents and 3D Tiles 1.1 - this array will have multiple elements. Content metadata only exists for available contents and is tightly packed by increasing tile index. To access individual content metadata, implementations may create a mapping from tile indices to content metadata indices."
+            "description": "An array of indexes to property tables containing content metadata. If the tile has a single content this array will have one element; if the tile has multiple contents - as supported by 3DTILES_multiple_contents and 3D Tiles 1.1 - this array will have multiple elements. Content metadata only exists for available contents and is tightly packed by increasing tile index. To access individual content metadata, implementations may create a mapping from tile indices to content metadata indices."
         },
         "subtreeMetadata": {
             "$ref": "metadataEntity.schema.json",


### PR DESCRIPTION
On today's episode of "Things that people wouldn't notice anyhow": The extension was referred to as `EXT_multiple_contents` but is called `3DTILES_multiple_contents`.

