### PR TITLE
Fix links from migration guide to tile formats

### DIFF
--- a/specification/TileFormats/glTF/MIGRATION.adoc
+++ b/specification/TileFormats/glTF/MIGRATION.adoc
@@ -5,7 +5,7 @@
 // links between ADOC files in sibling directories can be resolved.
 ifdef::env-github[]
 :url-specification: ../
-:url-specification-tileformats: {url-specification}Metadata/
+:url-specification-tileformats: {url-specification}TileFormats/
 :url-specification-tileformats-batched3dmodel: {url-specification-tileformats}Batched3DModel/
 :url-specification-tileformats-composite: {url-specification-tileformats}Composite/
 :url-specification-tileformats-instanced3dmodel: {url-specification-tileformats}Instanced3DModel/

--- a/specification/TileFormats/glTF/MIGRATION.adoc
+++ b/specification/TileFormats/glTF/MIGRATION.adoc
@@ -4,7 +4,7 @@
 // Definitions of the directory structure to ensure that relative
 // links between ADOC files in sibling directories can be resolved.
 ifdef::env-github[]
-:url-specification: ../
+:url-specification: ../../
 :url-specification-tileformats: {url-specification}TileFormats/
 :url-specification-tileformats-batched3dmodel: {url-specification-tileformats}Batched3DModel/
 :url-specification-tileformats-composite: {url-specification-tileformats}Composite/


### PR DESCRIPTION
A copy+paste error where
`:url-specification-tileformats: {url-specification}Metadata/`
should have been 
`:url-specification-tileformats: {url-specification}TileFormats/`