### PR TITLE
Formatting fixes for underscores

### DIFF
--- a/specification/README.adoc
+++ b/specification/README.adoc
@@ -1046,7 +1046,7 @@ Properties may include the following built-in statistics:
 | Object in which keys are property values (for enums, the enum name), and values are the number of occurrences of that property value
 |===
 
-Tileset authors may define their own additional statistics, like `_mode` in the example below. Application-specific statistics should use an underscore prefix (`_*`) and lowerCamelCase for consistency and to avoid conflicting with future built-in statistics.
+Tileset authors may define their own additional statistics, like `\_mode` in the example below. Application-specific statistics should use an underscore prefix (`\_*`) and lowerCamelCase for consistency and to avoid conflicting with future built-in statistics.
 
 [NOTE]
 .Example

--- a/specification/README.adoc
+++ b/specification/README.adoc
@@ -1046,7 +1046,7 @@ Properties may include the following built-in statistics:
 | Object in which keys are property values (for enums, the enum name), and values are the number of occurrences of that property value
 |===
 
-Tileset authors may define their own additional statistics, like `\_mode` in the example below. Application-specific statistics should use an underscore prefix (`\_*`) and lowerCamelCase for consistency and to avoid conflicting with future built-in statistics.
+Tileset authors may define their own additional statistics, like `\_mode` in the example below. Application-specific statistics should use an underscore prefix (`_*`) and lowerCamelCase for consistency and to avoid conflicting with future built-in statistics.
 
 [NOTE]
 .Example

--- a/specification/TileFormats/Batched3DModel/README.adoc
+++ b/specification/TileFormats/Batched3DModel/README.adoc
@@ -172,7 +172,7 @@ normal:   [xyz, xyz, xyz, ..., xyz, xyz, xyz, ..., xyz, xyz, xyz, ...]
 
 Note that a vertex can't belong to more than one model; in that case, the vertex needs to be duplicated so the ``batchId``s can be assigned.
 
-The `batchId` parameter is specified in a glTF link:https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#meshes[mesh primitive] by providing the `_BATCHID` attribute semantic, along with the index of the `batchId` link:https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#accessors[accessor]. For example,
+The `batchId` parameter is specified in a glTF link:https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#meshes[mesh primitive] by providing the `\_BATCHID` attribute semantic, along with the index of the `batchId` link:https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#accessors[accessor]. For example,
 
 [%unnumbered]
 [source,json]

--- a/specification/TileFormats/Batched3DModel/README.adoc
+++ b/specification/TileFormats/Batched3DModel/README.adoc
@@ -172,7 +172,7 @@ normal:   [xyz, xyz, xyz, ..., xyz, xyz, xyz, ..., xyz, xyz, xyz, ...]
 
 Note that a vertex can't belong to more than one model; in that case, the vertex needs to be duplicated so the ``batchId``s can be assigned.
 
-The `batchId` parameter is specified in a glTF link:https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#meshes[mesh primitive] by providing the `\_BATCHID` attribute semantic, along with the index of the `batchId` link:https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#accessors[accessor]. For example,
+The `batchId` parameter is specified in a glTF link:https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#meshes[mesh primitive] by providing the `_BATCHID` attribute semantic, along with the index of the `batchId` link:https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#accessors[accessor]. For example,
 
 [%unnumbered]
 [source,json]


### PR DESCRIPTION
The AsciiDoc preview contained italics caused by the `_` in code blocks, just above the example at https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification#metadata-statistics 

(The criteria for when this causes italics are not (yet) entirely clear for me. I noticed that the underscores do not always _have_ to be escaped, and in some cases, they _must not_ be escaped...)

![Cesium Underscore](https://user-images.githubusercontent.com/5597569/182382210-25ed8f33-220b-4a30-884d-4a430fa27b49.png)

