### PR TITLE
Updated RESOURCES.md

### DIFF
--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -85,6 +85,7 @@
 
 ### Selected Talks
 
+- _3D Tiles Next: Bringing Massive 3D Geospatial Data to the Web_, WebGL + WebGPU Meetup (April 2022). [Video and slides](https://cesium.com/learn/presentations/#webg-webgpu-meetup)
 - _3D Tiles Next: Data Performance for the Future of 3D Geospatial_, GEOINT 2022 Lightning Talk. [Slides](https://cesium.com/learn/presentations/#geoint-lightning-talk-2022)
 - _Rendering the World with 3D Tiles_, a guest lecture at Drexel University (February 2022). [Slides](https://cesium.com/learn/presentations/#rendering-the-world-with-3d-tiles)
 - _Introducing 3D Tiles Next_, at Web3D Conference 2021. [Video and slides](https://cesium.com/learn/presentations/#web3d-conference-2021)
@@ -105,7 +106,9 @@
 
 ### Selected Articles
 
+- [Fine Grained Metadata in 3D Tiles Next](https://cesium.com/blog/2022/05/31/fine-grained-metadata-in-3d-tiles-next/). May 2022.
 - [An End-to-End Guide to Photogrammetry with Mobile Devices](https://rd.nytimes.com/projects/an-end-to-end-guide-to-photogrammetry-with-mobile-devices). September 2021.
+- [Georeferencing 3D models for Cesium](https://medium.com/terria/georeferencing-3d-models-for-cesium-7ccf609ee2ef). May 2020.
 - [Create 3D Tiles from KML/COLLADA with Per-Building Data](https://cesium.com/blog/2020/04/09/kml-collada-metadata/). April 2020.
 - [Bring Your Cesium ion 3D Tiles and Bing Imagery in osgEarth](https://cesium.com/blog/2020/04/02/osgearth-supports-cesium-ion-assets/). April 2020.
 - [Taking City Visualization into the Third Dimension with Point Clouds, 3D Tiles, and deck.gl](https://eng.uber.com/3d-tiles-loadersgl/). October 2019.

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -13,30 +13,36 @@
 - [Cesium For O3DE](https://cesium.com/platform/cesium-for-o3de/) - An open source plugin for O3DE, the Open 3D Engine, for visualizing 3D Tiles
 - [3DTilesRendererJS](https://github.com/NASA-AMMOS/3DTilesRendererJS) - A renderer for 3D Tiles based on Three.js, developed by NASA-AMMOS
 - [three-loader-3dtiles](https://github.com/nytimes/three-loader-3dtiles) - A Three.js loader module for loading and visualizing 3D Tiles, developed by NY Times R&D.
-- [3DTilesViewer](https://github.com/ebeaufay/3DTilesViewer) - A viewer for 3D Tiles based on Three.js
+- [threedtiles](https://github.com/ebeaufay/threedtiles) - A viewer for 3D Tiles based on Three.js
 - [mapbox-3dtiles](https://github.com/Geodan/mapbox-3dtiles) - A 3D Tiles viewer, implemented as a Mapbox GL JS custom layer, based on Three.js
 - [iTowns](https://github.com/iTowns/itowns) - A Three.js-based framework for visualizing 3D geospatial data, including 3D Tiles
+- [giro3d](https://gitlab.com/giro3d/giro3d) - A framework for visualizing 3D geospatial data, based on Three.js
 - [Hexagon Geospatial Luciad](https://www.hexagongeospatial.com/) - Tools for converting, processing, optimizing, hosting, and visualizing geospatial data based on 3D Tiles 
 - [AGI STK](https://www.agi.com/products/stk) - A mission engineering software with visualization capabilities based on 3D Tiles
 - [Ecere GNOSIS](http://ecere.ca/) - A GIS visualization SDK with support for 3D Tiles
 - [TerriaJS](https://github.com/TerriaJS/terriajs) - A library for web-based geospatial data explorers, based on CesiumJS, with support for 3D Tiles
 - [GeoSolutions MapStore](https://www.geosolutionsgroup.com/technologies/mapstore/) - A framework for creating, managing and sharing maps with different types of geospatial content, including [support for 3D Tiles](https://www.geosolutionsgroup.com/blog/mapstore-release-2022_01_00/)
+- [3DCityDB-Web-Map-Client](https://github.com/3dcitydb/3dcitydb-web-map) A viewer for 3D Tiles and CityGML, based on CesiumJS
+- [deck.gl Tile3DLayer](https://deck.gl/docs/api-reference/geo-layers/tile-3d-layer) An implementation of a 3D Tiles renderer for deck.gl
+
 
 ### Implementations
 
 - [CesiumJS](https://github.com/CesiumGS/cesium) - An open source JavaScript runtime engine for visualizing 3D Tiles
 - [Cesium Native](https://github.com/CesiumGS/cesium-native) - A set of C++ libraries for 3D geospatial including an engine-agnostic 3D Tiles loader
 - [loaders.gl](https://github.com/visgl/loaders.gl) - A framework for loaders for geospatial data, including 3D Tiles
+- [Unity GIS Streaming Framework](https://github.com/Unity-Technologies/com.unity.gis.streaming-framework) - A framework for streaming 3D geospatial data for visualization in Unity, with 3D Tiles support
 
 ### Tools
 
 - [3d-tiles-validator](https://github.com/CesiumGS/3d-tiles-validator) - A validator for the tileset JSON file and tile formats of 3D Tiles 1.0
+- [blender-3d-tiler](https://gitee.com/cesium_processing/blender-3d-tiler) - A tool for tiling 3D models using the Blender API
 
 ### Sample Data
 
 - [3d-tiles-samples](https://github.com/CesiumGS/3d-tiles-samples) - Sample data sets demonstrating different capabilities of 3D Tiles
 - [3DTilesSampleData](https://github.com/NASA-AMMOS/3DTilesSampleData) - 3D Tiles data sets generated from the NASA Curiosity Rover data
-
+- [cesium_3dtiles_samples](https://github.com/bertt/cesium_3dtiles_samples) - Sample data sets demonstrating different features of 3D Tiles
 
 ### Generators
 
@@ -51,6 +57,7 @@
 - [nFrames](https://www.nframes.com/) - The SURE software system is an application for 3D reconstruction from images that can export the results as 3D Tiles data sets.
 - [Melown Vadstena](https://www.melowntech.com/products/vadstena/) - A software that can process drone-based close-range imagery and low-overlap nadir imagery, to create 3D models that can be exported in the 3D Tiles format.
 - [py3dtilers](https://github.com/VCityTeam/py3dtilers) - A tool and library for building 3D Tiles tilesets from OBJ, GeoJSON, IFC or CityGML input data. 
+- [py3dtiles](https://gitlab.com/Oslandia/py3dtiles) - A Python tool and library for creating and manipulating 3D Tiles
 - [gocesiumtiler](https://github.com/mfbonfigli/gocesiumtiler) - A Golang tool to convert point clouds stored as LAS files to Cesium 3D Tiles
 - [Entwine](https://entwine.io/) - A data organization library for massive point clouds, with the option to output 3D Tiles
 - [AGI GCS](https://www.agi.com/capabilities/geospatial-content-server) - Geospatial Content Server (GCS) is a hosting platform for 3D geospatial data that optimizes data and converts it into 3D Tiles for efficient streaming and visualization.
@@ -60,7 +67,11 @@
 - [4DMapper](https://4dmapper.com/) - A platform for visualizing, managing and delivering geospatial data, with 3D Tiles export
 - [cesium_pnt_generator](https://github.com/mattshax/cesium_pnt_generator) - A set of prototype scripts to convert LAS data into 3D Tiles
 - [cesium-point-cloud-generator](https://github.com/tum-gis/cesium-point-cloud-generator) - A tool for the generation of point cloud visualization datasets in the 3D Tiles format.
-- [Obj2Tiles](https://github.com/OpenDroneMap/Obj2Tiles) - Open source command-line tool for generating 3D Tiles. Supports Wavefront OBJ (.obj).
+- [pg2b3dm](https://github.com/Geodan/pg2b3dm) - A tool for converting 3D geometries from PostGIS into 3D Tiles B3DM tiles
+- [Obj2Tiles](https://github.com/OpenDroneMap/Obj2Tiles) - A command-line tool and library for converting OBJ files to 3D Tiles
+- [3dtiles](https://github.com/fanvanzh/3dtiles) - Tools for converting OSGB, Esri Shapefiles and FBX files into 3D Tiles
+- [gltf-to-3d-tiles](https://github.com/dreamergz/gltf-to-3d-tiles) - A tool for converting glTF models into GLB, B3DM or 3D Tiles
+
 
 ### Data Providers
 
@@ -74,7 +85,6 @@
 
 ### Selected Talks
 
-- _3D Tiles Next: Bringing Massive 3D Geospatial Data to the Web_, WebGL + WebGPU Meetup (April 2022). [Video and slides](https://cesium.com/learn/presentations/#webg-webgpu-meetup)
 - _3D Tiles Next: Data Performance for the Future of 3D Geospatial_, GEOINT 2022 Lightning Talk. [Slides](https://cesium.com/learn/presentations/#geoint-lightning-talk-2022)
 - _Rendering the World with 3D Tiles_, a guest lecture at Drexel University (February 2022). [Slides](https://cesium.com/learn/presentations/#rendering-the-world-with-3d-tiles)
 - _Introducing 3D Tiles Next_, at Web3D Conference 2021. [Video and slides](https://cesium.com/learn/presentations/#web3d-conference-2021)
@@ -95,9 +105,7 @@
 
 ### Selected Articles
 
-- [Fine Grained Metadata in 3D Tiles Next](https://cesium.com/blog/2022/05/31/fine-grained-metadata-in-3d-tiles-next/). May 2022.
 - [An End-to-End Guide to Photogrammetry with Mobile Devices](https://rd.nytimes.com/projects/an-end-to-end-guide-to-photogrammetry-with-mobile-devices). September 2021.
-- [Georeferencing 3D models for Cesium](https://medium.com/terria/georeferencing-3d-models-for-cesium-7ccf609ee2ef). May 2020.
 - [Create 3D Tiles from KML/COLLADA with Per-Building Data](https://cesium.com/blog/2020/04/09/kml-collada-metadata/). April 2020.
 - [Bring Your Cesium ion 3D Tiles and Bing Imagery in osgEarth](https://cesium.com/blog/2020/04/02/osgearth-supports-cesium-ion-assets/). April 2020.
 - [Taking City Visualization into the Third Dimension with Point Clouds, 3D Tiles, and deck.gl](https://eng.uber.com/3d-tiles-loadersgl/). October 2019.


### PR DESCRIPTION
Update the `RESOURCES.md` with the state that was originally only in `draft-1.1` (via https://github.com/CesiumGS/3d-tiles/commit/3bdaada6e0246b4273b81b515a695436f2503fb0 )

This should make https://github.com/CesiumGS/3d-tiles/pull/718 obsolete



