### PR TITLE
Clarifications for the 1.1 specification

### DIFF
--- a/specification/ImplicitTiling/README.adoc
+++ b/specification/ImplicitTiling/README.adoc
@@ -261,8 +261,6 @@ Each subtree contains tile availability, content availability, and child subtree
 
 Each type of availability is represented as a separate bitstream. Each bitstream is a 1D array where each element represents a node in the quadtree or octree. A 1 bit indicates that the element is available, while a 0 bit indicates that the element is unavailable. Alternatively, if all the bits in a bitstream are the same, a single constant value can be used instead.
 
-The bitstream is encoded in bytes that are stored in a <<implicittiling-buffers-and-buffer-views,buffer>>. Trailing bits that result from the number of nodes not being divisible by 8 shall be set to 0. 
-
 To form the 1D bitstream, the tiles are ordered with the following rules:
 
 * Within each level of the subtree, the tiles are ordered using the https://en.wikipedia.org/wiki/Z-order_curve[Morton Z-order curve]
@@ -404,7 +402,8 @@ Content availability (`contentAvailability`) is an array of content availability
 
 Availability may be represented either as a bitstream or a constant value. `bitstream` is an integer index that identifies the buffer view containing the availability bitstream. `constant` is an integer indicating whether all of the elements are available (`1`) or all are unavailable (`0`). `availableCount` is an integer indicating how many `1` bits exist in the availability bitstream.
 
-Availability bitstreams are packed in binary using the format described in the xref:{url-specification-metadata}README.adoc#metadata-booleans[Booleans] section of the 3D Metadata Specification.
+Availability bitstreams are packed in binary using the format described in the xref:{url-specification-metadata}README.adoc#metadata-booleans[Booleans] section of the 3D Metadata Specification. Trailing bits of availability bitstreams that result from the number of nodes not being divisible by 8 shall be set to 0.
+
 
 [NOTE]
 .Example

--- a/specification/ImplicitTiling/README.adoc
+++ b/specification/ImplicitTiling/README.adoc
@@ -261,6 +261,8 @@ Each subtree contains tile availability, content availability, and child subtree
 
 Each type of availability is represented as a separate bitstream. Each bitstream is a 1D array where each element represents a node in the quadtree or octree. A 1 bit indicates that the element is available, while a 0 bit indicates that the element is unavailable. Alternatively, if all the bits in a bitstream are the same, a single constant value can be used instead.
 
+The bitstream is encoded in bytes that are stored in a <<implicittiling-buffers-and-buffer-views,buffer>>. Trailing bits that result from the number of nodes not being divisible by 8 shall be set to 0. 
+
 To form the 1D bitstream, the tiles are ordered with the following rules:
 
 * Within each level of the subtree, the tiles are ordered using the https://en.wikipedia.org/wiki/Z-order_curve[Morton Z-order curve]

--- a/specification/ImplicitTiling/README.adoc
+++ b/specification/ImplicitTiling/README.adoc
@@ -296,7 +296,7 @@ image::figures/tile-availability.png[Tile Availability]
 [#implicittiling-content-availability]
 ==== Content Availability
 
-Content availability determines which tiles have a content resource. The content resource is located using the `content.uri` template URI. If there are no tiles with a content resource, `tile.content` shall be omitted.
+Content availability determines which tiles have a content resource. The content resource is located using the template URI of the tile content. When the tile has xref:{url-specification}README.adoc#core-tile-content[multiple contents], then there is one content availability bitstream for each content. If there are no tiles with a content resource, then `tile.content` and `tile.contents` shall be omitted.
 
 Content availability has the following restrictions:
 

--- a/specification/Metadata/README.adoc
+++ b/specification/Metadata/README.adoc
@@ -70,6 +70,13 @@ Components of a schema are listed below, and implementations may define addition
 
 IDs (`id`) are unique <<metadata-identifiers,identifiers>> for a schema.
 
+[NOTE]
+.Informative
+====
+The schema ID is _required_ for each schema. The main purpose of this ID is to be able to resolve possible ambiguities. The exact mechanism for this disabiguation depends on the client application, and how the access to metadata properties is implemented. But the schema ID makes sure that a compound identifier of the form `<schema-id>.<class-name>.<property-name>` is globally unique, even when the same class name and property name appears in multiple schemas.
+====
+
+
 [#metadata-version]
 ==== Version
 

--- a/specification/README.adoc
+++ b/specification/README.adoc
@@ -145,7 +145,7 @@ The CRS of a tileset may be defined explicitly, as part of the <<core-metadata,t
 
 An additional <<core-tile-transforms,tile transform>> may be applied to transform a tile's local coordinate system to the parent tile's coordinate system.
 
-The <<core-region,region>> bounding volume specifies bounds using a geographic coordinate system (latitude, longitude, height), specifically, https://epsg.org/crs_4979/WGS-84.html[EPSG 4979]. The reference ellipsoid is assumed to be the same as the reference ellipsoid of the tileset.
+The <<core-region,region>> bounding volume specifies bounds using a geographic coordinate system (latitude, longitude, height). Specifically, https://epsg.org/crs_4979/WGS-84.html[EPSG 4979], but with the latitude and longitude given in _radians_ instead of _degrees_. The reference ellipsoid is assumed to be the same as the reference ellipsoid of the tileset.
 
 [#core-concepts]
 == Concepts

--- a/specification/schema/Schema/class.property.schema.json
+++ b/specification/schema/Schema/class.property.schema.json
@@ -54,7 +54,7 @@
             ]
         },
         "componentType": {
-            "description": "The datatype of the element's components. Only applicable to `SCALAR`, `VECN`, and `MATN` types.",
+            "description": "The datatype of the element's components. Required for `SCALAR`, `VECN`, and `MATN` types, and disallowed for other types.",
             "anyOf": [
                 {
                     "const": "INT8"
@@ -93,7 +93,7 @@
         },
         "enumType": {
             "type": "string",
-            "description": "Enum ID as declared in the `enums` dictionary. Required when `type` is `ENUM`."
+            "description": "Enum ID as declared in the `enums` dictionary. Required when `type` is `ENUM`. Disallowed when `type` is not `ENUM`"
         },
         "array": {
             "type": "boolean",
@@ -112,19 +112,19 @@
         },
         "offset": {
             "$ref": "definitions.schema.json#/definitions/numericValue",
-            "description": "An offset to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`."
+            "description": "An offset to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`. Not applicable to variable-length arrays."
         },
         "scale": {
             "$ref": "definitions.schema.json#/definitions/numericValue",
-            "description": "A scale to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`."
+            "description": "A scale to apply to property values. Only applicable to `SCALAR`, `VECN`, and `MATN` types when the component type is `FLOAT32` or `FLOAT64`, or when the property is `normalized`. Not applicable to variable-length arrays."
         },
         "max": {
             "$ref": "definitions.schema.json#/definitions/numericValue",
-            "description": "Maximum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the maximum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied."
+            "description": "Maximum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the maximum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied. Not applicable to variable-length arrays."
         },
         "min": {
             "$ref": "definitions.schema.json#/definitions/numericValue",
-            "description": "Minimum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the minimum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied."
+            "description": "Minimum allowed value for the property. Only applicable to `SCALAR`, `VECN`, and `MATN` types. This is the minimum of all property values, after the transforms based on the `normalized`, `offset`, and `scale` properties have been applied. Not applicable to variable-length arrays."
         },
         "required": {
             "type": "boolean",

--- a/specification/schema/Statistics/statistics.class.schema.json
+++ b/specification/schema/Statistics/statistics.class.schema.json
@@ -3,7 +3,7 @@
     "$id": "statistics.class.schema.json",
     "title": "Class Statistics",
     "$ref": "rootProperty.schema.json",
-    "description": "Statistics about entities that conform to a class.",
+    "description": "Statistics about entities that conform to a class that was defined in a metadata schema.",
     "properties": {
         "count": {
             "type": "integer",

--- a/specification/schema/Statistics/statistics.schema.json
+++ b/specification/schema/Statistics/statistics.schema.json
@@ -13,8 +13,5 @@
                 "$ref": "statistics.class.schema.json"
             }
         }
-    },
-    "required": [
-        "classes"
-    ]
+    }
 }

--- a/specification/schema/Statistics/statistics.schema.json
+++ b/specification/schema/Statistics/statistics.schema.json
@@ -7,11 +7,14 @@
     "properties": {
         "classes": {
             "type": "object",
-            "description": "A dictionary, where each key corresponds to a class ID in the `classes` dictionary and each value is an object containing statistics about entities that conform to the class.",
+            "description": "A dictionary, where each key corresponds to a class ID in the `classes` dictionary of the metatata schema that was defined for the tileset that contains these statistics. Each value is an object containing statistics about entities that conform to the class.",
             "minProperties": 1,
             "additionalProperties": {
                 "$ref": "statistics.class.schema.json"
             }
         }
-    }
+    },
+    "required": [
+        "classes"
+    ]
 }

--- a/specification/schema/boundingVolume.schema.json
+++ b/specification/schema/boundingVolume.schema.json
@@ -17,7 +17,7 @@
         },
         "region": {
             "type": "array",
-            "description": "An array of six numbers that define a bounding geographic region in EPSG:4979 coordinates with the order [west, south, east, north, minimum height, maximum height]. Longitudes and latitudes are in radians, and heights are in meters above (or below) the WGS84 ellipsoid.",
+            "description": "An array of six numbers that define a bounding geographic region in EPSG:4979 coordinates with the order [west, south, east, north, minimum height, maximum height]. Longitudes and latitudes are in radians. The range for latitudes is [-PI/2,PI/2]. The range for longitudes is [-PI,PI]. The value that is given as the 'south' of the region shall not be larger than the value for the 'north' of the region. The heights are in meters above (or below) the WGS84 ellipsoid. The 'minimum height' shall not be larger than the 'maximum height'.",
             "items": {
                 "type": "number"
             },
@@ -26,7 +26,7 @@
         },
         "sphere": {
             "type": "array",
-            "description": "An array of four numbers that define a bounding sphere. The first three elements define the x, y, and z values for the center of the sphere. The last element (with index 3) defines the radius in meters.",
+            "description": "An array of four numbers that define a bounding sphere. The first three elements define the x, y, and z values for the center of the sphere. The last element (with index 3) defines the radius in meters. The radius shall not be negative.",
             "items": {
                 "type": "number"
             },

--- a/specification/schema/properties.schema.json
+++ b/specification/schema/properties.schema.json
@@ -7,11 +7,11 @@
     "properties": {
         "maximum": {
             "type": "number",
-            "description": "The maximum value of this property of all the features in the tileset."
+            "description": "The maximum value of this property of all the features in the tileset. The maximum value shall not be larger than the minimum value."
         },
         "minimum": {
             "type": "number",
-            "description": "The minimum value of this property of all the features in the tileset."
+            "description": "The minimum value of this property of all the features in the tileset. The maximum value shall not be larger than the minimum value."
         }
     },
     "required": [

--- a/specification/schema/tileset.schema.json
+++ b/specification/schema/tileset.schema.json
@@ -62,7 +62,7 @@
         },
         "extensionsRequired": {
             "type": "array",
-            "description": "Names of 3D Tiles extensions required to properly load this tileset.",
+            "description": "Names of 3D Tiles extensions required to properly load this tileset. Each element of this array shall also be contained in `extensionsUsed`.",
             "items": {
                 "type": "string"
             },


### PR DESCRIPTION
Addressing https://github.com/CesiumGS/3d-tiles/issues/711 : I'll replicate the bullet point list here, and mark the parts that have already been solved with checkboxes.


- [x] For [`boundingVolume`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/boundingVolume.schema.json):

  - The `latitude` and `longitude` for the `region` bounding volume should be constrained to the ranges that are mentioned in https://spatialreference.org/ref/epsg/4979/ (-180.0000, -90.0000, 180.0000, 90.0000)
    - **NOTE**: It's actually given in radians, deviating from the EPSG spec. Emphasized this in the text.
  - The minimum height should not be larger than the maximum height
  - The `south` may not be greater than the `north`
  - The `radius` of the bounding sphere should not be negative

- [x] For [`properties`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/properties.schema.json) (although deprecated?)

  - The `maximum` should not be smaller than the `minimum`

- [x] For [`statistics`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/Statistics/statistics.schema.json):

  - <strike>The `classes` should be required</strike> Based on internal discussion, it should remain optional
  - [x] The desciption says *"A dictionary, where each key corresponds to a class ID in the `classes` dictionary and..."* - this is confusing. It should say *"... in the `classes` dictionary **of the metadata schema of the containing tileset**, and ..."*
  - [x] Similarly the `statistics.class.properties` description should refer to the _class of the metadata schema_


- [ ] For [`statistics.class.property`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/Statistics/statistics.class.property.schema.json#L8):

  - One **could** add constraints (like `!(min>max)`) here. But one could go pretty far, e.g. `!(mean>min)`, and even make mathematically based constraints about the possible values of the standard deviation and such. Maybe this is a step too far for now (there are more important constraints/checks to be added)


- [ ] For [`class.property`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/Schema/class.property.schema.json#L94):

  - [x] The `enumType` should be disallowed for non-`"ENUM"` types
  - [x] I think the `componentType` should be required for the SCALAR/VECn/MATn types.
  - [ ] One could go full pedantic mode, and require `min`/`max` to be integer values when the component type is integral, and require the bounds of the values to be obeyed. For a `UINT8` (without `offset` or `scale`), a `max=0.8` does not make sense, and neither does a `min=-10000`.
  - [x] The `min/max/offset/scale` do not make sense for variable length arrays. This is mentioned at https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/Metadata#minimum-and-maximum-values but could also be mentioned in the schema
 
- [ ] For [`templateUri`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/templateUri.schema.json#L6)

  - One could consider to add the requirement that the variables `{level}`, `{x}`, `{y}`, `{z}` MUST be present for the respective tree types. For now, I assume that any `{unknown}` expression is an error, and "missing" ones (e.g. a missing `{z}` for an `OCTREE`) should cause a warning.

- [ ] For [`subtree`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/Subtree/subtree.schema.json#L16)

  - I thought that one _could_ add the constraint that buffer views may not overlap, so that
    ```
    { byteOffset: 0, byteLength: 10 }
    { byteOffset: 5, byteLength: 5 }
    ```
    was disallowed. But I don't see a _strong_ reason to disallow that (and glTF apparently _does_ allow this as well...)


- [ ] For [`availability`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/Subtree/availability.schema.json#L13)

  - [ ] One could add a constraint that `availableCount` may not be larger than `bufferView.byteLength/8` (?)
  - [x] The [Content Availability](https://github.com/CesiumGS/3d-tiles/blob/draft-1.1/specification/ImplicitTiling/README.adoc#content-availability) section could be a bit clearer about multiple contents (it only refers to `tile.content` now, and does not mention `tile.contents`)
  - [x] We could add a rule to say that trailing (unused) bits in an availability buffer should always be `0`

- [ ] For [`tile`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/tile.schema.json#L35) : 

  - One could consider to add constraints to the `transform`. From "weak" to strict: It should probably not be zero. It should probably be invertible. It should probably have a positive determinant. It should probably not contain skew/shear components. It should probably be decomposable into translation, rotation, scale components. See https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#transformations for inspiration.
  - The conditions for when `content`/`contents` MUST be present are difficult. One could say that one of them MUST be present when `implicitTiling` is present, but ... strictly speaking, only when there is any `contentAvailability[i]=true`. 

- [x] For [`schema`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/Schema/schema.schema.json#L8)

  - [x] The `schema.id` is marked as 'required' and must match the usual "ID regex". The ID may eventually be used (e.g. by CesiumJS) to uniquely identify properties in Custom Shaders, or to identify that the `schema` objects of two loaded tilesets are _the same_ schema. But the spec should (at least as an 'Implementation Note') describe the purpose, and give usage hints - for example, whether it should only be a semi-random "unique ID", or a human-readable string, or maybe something that includes a concept of "versioning".

- [x] For [`tileset`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/tileset.schema.json#L54): 
  - One could mention that each element of `extensionsRequired` must also appear in `extensionsUsed`

- [ ] Structural:

  - It should be clarified under which conditions certain constraints are condidered to be satisfied. For example, when a tile defines a `geometricError` that is _larger_ than the `geometricError` of the parent, **but** overrides this geometric error with metdata so that it is _smaller_ than that of the parent, should this cause a validation issue? 

<strike>
- [ ] For [`subtree`](https://github.com/CesiumGS/3d-tiles/blob/aafebe993986aa9c668d35a63a42cc72ccdcc327/specification/schema/Subtree/subtree.schema.json#L16)

  - The specification should mention that for _binary_ subtrees, only **one** `buffer` may omit the `uri` property (only one buffer may refer to the binary chunk)
    - This is mentioned in the text at https://github.com/CesiumGS/3d-tiles/blob/draft-1.1/specification/ImplicitTiling/README.adoc#buffers-and-buffer-views : 
      > In the Binary Format the first buffer may instead refer to the binary chunk of the subtree file, in which case the uri property shall be undefined. 
</strike>

- [ ] Regarding `extensionsUsed`: 

  - The spec says at https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification#extensions-1 
    > All extensions used in a tileset or any descendant external tilesets shall be listed in the entry tileset JSON 

    This should be reviewed and possibly clarified. If one tileset refers to an external tileset that does *not* use any extensions, but is later modified to use a certain extension, then the containing tileset may become "invalid", because it does not declare this extension as `extensionsUsed`. While this makes sense from the perspective of _knowing which extensions will be used as a whole_, it somewhat contradicts the idea of external tilesets being "building blocks" that can be combined arbitrarily.

 