### PR TITLE
Fix conflict in `BinaryBodyReference.componentType`

### DIFF
--- a/specification/TileFormats/FeatureTable/README.md
+++ b/specification/TileFormats/FeatureTable/README.md
@@ -140,7 +140,7 @@ The offset into the buffer in bytes.
 The datatype of components in the property.
 
 * **Type**: `string`
-* **Required**: Yes
+* **Required**: No
 * **Allowed values**:
    * `"BYTE"`
    * `"UNSIGNED_BYTE"`


### PR DESCRIPTION
While looking through the specs I found a typo that says `BinaryBodyReference.componentType` should be required, even though it is not.