### PR TITLE
Fix wording in description of subtree buffer schema

### DIFF
--- a/specification/schema/Subtree/buffer.schema.json
+++ b/specification/schema/Subtree/buffer.schema.json
@@ -7,7 +7,7 @@
     "properties": {
         "uri": {
             "type": "string",
-            "description": "The URI (or IRI) of the external schema file. Relative paths are relative to the file containing the buffer JSON. `uri` is required when using the JSON subtree format and not required when using the binary subtree format - when omitted the buffer refers to the binary chunk of the subtree file. Data URIs are not allowed.",
+            "description": "The URI (or IRI) of the file that contains the binary buffer data. Relative paths are relative to the file containing the buffer JSON. `uri` is required when using the JSON subtree format and not required when using the binary subtree format - when omitted the buffer refers to the binary chunk of the subtree file. Data URIs are not allowed.",
             "format": "iri-reference"
         },
         "byteLength": {


### PR DESCRIPTION
It mentioned an "external schema file", but should be the "file that contains the binary buffer data"
