### PR TITLE
Additions to Point Cloud spec

### DIFF
--- a/specification/TileFormats/PointCloud/README.adoc
+++ b/specification/TileFormats/PointCloud/README.adoc
@@ -175,7 +175,7 @@ These semantics define global properties for all points.
 
 | `POINTS_LENGTH`
 | `uint32`
-| The number of points to render. The length of each array value for a point semantic should be equal to this.
+| The number of points to render. This must be greater than zero. The length of each array value for a point semantic should be equal to this.
 | Yes.
 
 | `RTC_CENTER`

--- a/specification/TileFormats/PointCloud/README.adoc
+++ b/specification/TileFormats/PointCloud/README.adoc
@@ -246,6 +246,8 @@ Compressed attributes should be decompressed before any other transforms are app
 
 If more than one color semantic is defined, the precedence order is `RGBA`, `RGB`, `RGB565`, then `CONSTANT_RGBA`. For example, if a tile's Feature Table contains both `RGBA` and `CONSTANT_RGBA` properties, the runtime would render with per-point colors using `RGBA`.
 
+Point colors are defined in sRGB color space.
+
 If no color semantics are defined, the runtime is free to color points using an application-specific default color.
 
 In any case, xref:{url-specification-styling}README.adoc#styling-styling[3D Tiles Styling] may be used to change the final rendered color and other visual properties at runtime.

--- a/specification/TileFormats/glTF/MIGRATION.adoc
+++ b/specification/TileFormats/glTF/MIGRATION.adoc
@@ -57,6 +57,7 @@ xref:{url-specification-tileformats-pointcloud}README.adoc#tileformats-pointclou
 * https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_meshopt_compression[`EXT_meshopt_compression`] and https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_mesh_quantization[`KHR_mesh_quantization`] may be used for point cloud compression. link:https://github.com/CesiumGS/3d-tiles/tree/main/extensions/3DTILES_draco_point_compression/[`3DTILES_draco_point_compression`] is not directly supported in glTF because https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_draco_mesh_compression[`KHR_draco_mesh_compression`] only supports triangle meshes.
 * Batch IDs and Batch Tables can be represented using https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_mesh_features[`EXT_mesh_features`] and https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_structural_metadata[`EXT_structural_metadata`].
 * `CONSTANT_RGBA` is not directly supported in glTF, but can be achieved with materials or per-point colors.
+* If `COLOR` or `CONSTANT_RGBA` are present, they should be converted from sRGB to linear RGB in the glTF.
 
 .Point Clouds in 3D Tiles 1.0, and the corresponding representation in 3D Tiles 1.1
 image::figures/migration-pnts.png[pnts]


### PR DESCRIPTION
The Point Cloud guide doesn't mention anything about its colors being stored in sRGB color space. This leads to unexpected rendering differences when migrating from `pnts` to glTF, because a glTF stores colors in linear RGB.

To minimize future confusion, I added some lines about point clouds storing colors in sRGB, and how they must be converted to linear RGB for glTFs.

I also added a line requiring `POINTS_LENGTH` to be greater than zero, as suggested in https://github.com/CesiumGS/3d-tiles/issues/711#issuecomment-1387331864.

@javagl could you review? Feel free to rewrite my lines if they are not clear enough.