### PR TITLE
Fix link definitions

### DIFF
--- a/specification/README.adoc
+++ b/specification/README.adoc
@@ -16,9 +16,9 @@ ifdef::env-github[]
 :url-specification-implicittiling: {url-specification}ImplicitTiling/
 :url-specification-metadata: {url-specification}Metadata/
 :url-specification-metadata-referenceimplementation: {url-specification-metadata}ReferenceImplementation/
-:url-specification-metadata-referenceimplementation-schema: {url-specification-metadata-referenceImplementation]Schema/
+:url-specification-metadata-referenceimplementation-schema: {url-specification-metadata-referenceImplementation}Schema/
 :url-specification-metadata-semantics: {url-specification-metadata}Semantics/
-:url-specification-styling: {url-specification}/Styling
+:url-specification-styling: {url-specification}/Styling/
 :url-specification-tileformats: {url-specification}TileFormats/
 :url-specification-tileformats-batched3dmodel: {url-specification-tileformats}Batched3DModel/
 :url-specification-tileformats-batchtable: {url-specification-tileformats}BatchTable/

--- a/specification/README.adoc
+++ b/specification/README.adoc
@@ -18,7 +18,7 @@ ifdef::env-github[]
 :url-specification-metadata-referenceimplementation: {url-specification-metadata}ReferenceImplementation/
 :url-specification-metadata-referenceimplementation-schema: {url-specification-metadata-referenceImplementation}Schema/
 :url-specification-metadata-semantics: {url-specification-metadata}Semantics/
-:url-specification-styling: {url-specification}/Styling/
+:url-specification-styling: {url-specification}Styling/
 :url-specification-tileformats: {url-specification}TileFormats/
 :url-specification-tileformats-batched3dmodel: {url-specification-tileformats}Batched3DModel/
 :url-specification-tileformats-batchtable: {url-specification-tileformats}BatchTable/


### PR DESCRIPTION
The links to 

- "Metadata Schema Reference Implementation" in https://github.com/CesiumGS/3d-tiles/blob/c32e4cf25dc094c555e78429eec82ff6d387101e/specification/README.adoc#metadata-schema and 
- "declarative styling language" in https://github.com/CesiumGS/3d-tiles/blob/c32e4cf25dc094c555e78429eec82ff6d387101e/specification/README.adoc#metadata-statistics

had been broken due to typos in the `ifdef::env-github[]` block.

The corresponding sections after this PR are
- https://github.com/javagl/3d-tiles/tree/draft-1.1-link-fixes/specification#metadata-schema
- https://github.com/javagl/3d-tiles/tree/draft-1.1-link-fixes/specification#metadata-statistics


