### PR TITLE
Fix broken link to `Cesium3DTileBatchTable.js`

### DIFF
--- a/extensions/3DTILES_bounding_volume_S2/README.md
+++ b/extensions/3DTILES_bounding_volume_S2/README.md
@@ -384,4 +384,4 @@ _This section is non-normative_
 
 - [S2Geometry Reference C++ Implementation](https://github.com/google/s2geometry/tree/master/src/s2)
 - [S2Geometry Reference Java Implementation](https://github.com/google/s2-geometry-library-java/tree/master/src/com/google/common/geometry)
-- [S2Cell.js in CesiumJS](https://github.com/CesiumGS/cesium/blob/master/Source/Core/S2Cell.js)
+- [S2Cell.js in CesiumJS](https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/S2Cell.js)

--- a/extensions/3DTILES_draco_point_compression/README.md
+++ b/extensions/3DTILES_draco_point_compression/README.md
@@ -156,7 +156,7 @@ case `POINT_CLOUD_SEQUENTIAL_ENCODING` should not be applied.
 _This section is non-normative._
 
 * [Draco Open Source Library](https://github.com/google/draco)
-* [Cesium Draco Decoder Implementation](https://github.com/CesiumGS/cesium/blob/main/Source/Workers/decodeDraco.js)
+* [Cesium Draco Decoder Implementation](https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/WorkersES6/decodeDraco.js)
 
 ## Property reference
 

--- a/specification/README.adoc
+++ b/specification/README.adoc
@@ -515,7 +515,7 @@ The full computed transforms, taking into account the <<core-y-up-to-z-up,glTF _
 
 _This section is informative_
 
-The following JavaScript code shows how to compute this using Cesium's https://github.com/CesiumGS/cesium/blob/main/Source/Core/Matrix4.js[Matrix4] and https://github.com/CesiumGS/cesium/blob/main/Source/Core/Matrix3.js[Matrix3] types.
+The following JavaScript code shows how to compute this using Cesium's https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/Matrix4.js[Matrix4] and https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/Matrix3.js[Matrix3] types.
 
 [%unnumbered]
 [source,javascript]

--- a/specification/TileFormats/BatchTable/README.adoc
+++ b/specification/TileFormats/BatchTable/README.adoc
@@ -240,5 +240,5 @@ var geographicArray = new Float64Array(batchTableBinary.buffer, byteOffset, geog
 var geographicOfFeature = positionArray.subarray(batchId * numberOfComponents, batchId * numberOfComponents + numberOfComponents); // Using subarray creates a view into the array, and not a new array.
 ----
 
-Code for reading the Batch Table can be found in https://github.com/CesiumGS/cesium/blob/main/Source/Scene/Cesium3DTileBatchTable.js[`Cesium3DTileBatchTable.js`] in the CesiumJS implementation of 3D Tiles.
+Code for reading the Batch Table can be found in https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Scene/Cesium3DTileBatchTable.js[`Cesium3DTileBatchTable.js`] in the CesiumJS implementation of 3D Tiles.
 

--- a/specification/TileFormats/Batched3DModel/README.adoc
+++ b/specification/TileFormats/Batched3DModel/README.adoc
@@ -233,6 +233,6 @@ An explicit file extension is optional. Valid implementations may ignore it and 
 _This section is informative_
 
 Code for reading the header can be found in
-https://github.com/CesiumGS/cesium/blob/main/Source/Scene/Batched3DModel3DTileContent.js[`Batched3DModelTileContent.js`]
+https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Scene/B3dmParser.js[`B3dmParser.js`]
 in the CesiumJS implementation of 3D Tiles.
 

--- a/specification/TileFormats/Composite/README.adoc
+++ b/specification/TileFormats/Composite/README.adoc
@@ -113,5 +113,5 @@ _This section is informative_
 
 * link:https://github.com/Geopipe/gltf2glb[Python `packcmpt` tool in gltf2glb toolset] contains code for combining one or more _Batched 3D Model_ or _Instanced 3D Model_ tiles into a single Composite tile file.
 * Code for reading the header can be found in
-link:https://github.com/CesiumGS/cesium/blob/main/Source/Scene/Composite3DTileContent.js[`Composite3DTileContent.js`]
+link:https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Scene/Composite3DTileContent.js[`Composite3DTileContent.js`]
 in the CesiumJS implementation of 3D Tiles.

--- a/specification/TileFormats/FeatureTable/README.adoc
+++ b/specification/TileFormats/FeatureTable/README.adoc
@@ -94,5 +94,5 @@ var positionArray = new Float32Array(featureTableBinary.buffer, byteOffset, feat
 var position = positionArray.subarray(featureId * 3, featureId * 3 + 3); // Using subarray creates a view into the array, and not a new array.
 ----
 
-Code for reading the Feature Table can be found in link:https://github.com/CesiumGS/cesium/blob/main/Source/Scene/Cesium3DTileFeatureTable.js[`Cesium3DTileFeatureTable.js`] in the CesiumJS implementation of 3D Tiles.
+Code for reading the Feature Table can be found in link:https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Scene/Cesium3DTileFeatureTable.js[`Cesium3DTileFeatureTable.js`] in the CesiumJS implementation of 3D Tiles.
 

--- a/specification/TileFormats/Instanced3DModel/README.adoc
+++ b/specification/TileFormats/Instanced3DModel/README.adoc
@@ -248,7 +248,7 @@ These define `up` and `right` using the oct-encoding described in link:http://jc
 [NOTE]
 .Informative
 ====
-An implementation for encoding and decoding these unit vectors can be found in CesiumJS's link:https://github.com/CesiumGS/cesium/blob/main/Source/Core/AttributeCompression.js[AttributeCompression]
+An implementation for encoding and decoding these unit vectors can be found in CesiumJS's link:https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/AttributeCompression.js[AttributeCompression]
 module.
 ====
 

--- a/specification/TileFormats/PointCloud/README.adoc
+++ b/specification/TileFormats/PointCloud/README.adoc
@@ -266,7 +266,7 @@ Oct-encoding is described in link:http://jcgt.org/published/0003/02/01/[_A Surve
 [NOTE]
 .Informative
 ====
-An implementation for encoding and decoding these unit vectors can be found in CesiumJS's link:https://github.com/CesiumGS/cesium/blob/main/Source/Core/AttributeCompression.js[AttributeCompression]
+An implementation for encoding and decoding these unit vectors can be found in CesiumJS's link:https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/AttributeCompression.js[AttributeCompression]
 module.
 ====
 
@@ -481,5 +481,5 @@ An explicit file extension is optional. Valid implementations may ignore it and 
 
 _This section is informative_
 
-Code for reading the header can be found in link:https://github.com/CesiumGS/cesium/blob/main/Source/Scene/PointCloud3DTileContent.js[`PointCloud3DModelTileContent.js`] in the CesiumJS implementation of 3D Tiles.
+Code for reading the header can be found in link:https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Scene/PntsParser.js[`PntsParser.js`] in the CesiumJS implementation of 3D Tiles.
 


### PR DESCRIPTION
The link to the `Cesium3DTileBatchTable.js` file was wrong -- it was from before CesiumJS was reorganized into packages. This PR replaces it with the new working link.