### PR TITLE
Update 'draft-1.1' to 'main' in links

### DIFF
--- a/reference-cards/1.1/README.md
+++ b/reference-cards/1.1/README.md
@@ -4,7 +4,7 @@
 
 The [**3D Tiles 1.1 Reference Card**](../../3d-tiles-reference-card-1.1.pdf) is an overview of the new concepts that are introduced with 3D Tiles 1.1.
 
-This guide augments the [3D Tiles 1.0 Reference Card](../../3d-tiles-reference-card.pdf) and the fully detailed [3D Tiles 1.1 specification](https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification). 
+This guide augments the [3D Tiles 1.0 Reference Card](../../3d-tiles-reference-card.pdf) and the fully detailed [3D Tiles 1.1 specification](https://github.com/CesiumGS/3d-tiles/tree/main/specification). 
 
 
 ## Source

--- a/specification/ImplicitTiling/README.adoc
+++ b/specification/ImplicitTiling/README.adoc
@@ -370,7 +370,7 @@ Properties assigned to subtrees provide metadata about the subtree as a whole. S
 
 _Defined in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/Subtree/subtree.schema.json[`subtree.schema.json`]._
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/Subtree/subtree.schema.json[`subtree.schema.json`]._
 endif::[]
 ifndef::env-github[]
 <<reference-schema-subtree,`subtree.schema.json`>>._

--- a/specification/Metadata/ReferenceImplementation/PropertyTable/README.adoc
+++ b/specification/Metadata/ReferenceImplementation/PropertyTable/README.adoc
@@ -25,14 +25,14 @@ The xref:{url-specification-metadata}README.adoc#metadata-3d-metadata-specificat
 * xref:{url-specification-implicittiling}README.adoc#implicittiling-implicit-tiling[3D Tiles Metadata Implicit Tilesets] - Assigns metadata to tilesets, tiles, groups, and contents in a 3D Tiles tileset. A property table is defined for subtrees of an implicit tile hierarchy, and stores metadata that is associated with the nodes of such a subtree.
 * https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_structural_metadata[`EXT_structural_metadata`] -- Assigns metadata to vertices, texels, and features in a glTF asset. A property table is defined in the top-level extension object. The property values are stored in standard glTF buffer views.
 
-The full JSON schema definition for this implementation can be found in link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/PropertyTable/[the PropertyTable directory of the specification].
+The full JSON schema definition for this implementation can be found in link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/PropertyTable/[the PropertyTable directory of the specification].
 
 [#metadata-referenceimplementation-propertytable-property-tables]
 == Property Tables
 
 _Defined in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/PropertyTable/propertyTable.schema.json[`propertyTable.schema.json`]._
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/PropertyTable/propertyTable.schema.json[`propertyTable.schema.json`]._
 endif::[]
 ifndef::env-github[]
 <<reference-schema-propertytable,`propertyTable.schema.json`>>._
@@ -74,7 +74,7 @@ A `tree_survey_2021-09-29` property table, implementing the `tree` class defined
 
 _Defined in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/PropertyTable/propertyTable.schema.json[`propertyTable.schema.json`]._
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/PropertyTable/propertyTable.schema.json[`propertyTable.schema.json`]._
 endif::[]
 ifndef::env-github[]
 <<reference-schema-propertytable,`propertyTable.schema.json`>>._

--- a/specification/Metadata/ReferenceImplementation/Schema/README.adoc
+++ b/specification/Metadata/ReferenceImplementation/Schema/README.adoc
@@ -18,14 +18,14 @@ The xref:{url-specification-metadata}README.adoc#metadata-3d-metadata-specificat
 * xref:{url-specification-implicittiling}README.adoc#implicittiling-implicit-tiling[3D Tiles Metadata Implicit Tilesets] - Assigns metadata to tilesets, tiles, groups, and contents in a 3D Tiles tileset. A property table is defined for subtrees of an implicit tile hierarchy, and stores metadata that is associated with the nodes of such a subtree.
 * https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_structural_metadata[`EXT_structural_metadata`] -- Assigns metadata to vertices, texels, and features in a glTF asset. A property table is defined in the top-level extension object. The property values are stored in standard glTF buffer views.
 
-The full JSON schema definition for this implementation can be found in link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/Schema/[the Schema directory of the specification].
+The full JSON schema definition for this implementation can be found in link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/Schema/[the Schema directory of the specification].
 
 [#metadata-referenceimplementation-schema-schema]
 == Schema
 
 _Defined in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/Schema/schema.schema.json[`schema.schema.json`]._
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/Schema/schema.schema.json[`schema.schema.json`]._
 endif::[]
 ifndef::env-github[]
 <<reference-schema-schema,`schema.schema.json`>>._
@@ -58,7 +58,7 @@ Schema with a `tree` class, and a `speciesEnum` enum that defines different spec
 
 _Defined in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/Schema/class.schema.json[`class.schema.json`]._
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/Schema/class.schema.json[`class.schema.json`]._
 endif::[]
 ifndef::env-github[]
 <<reference-schema-class,`class.schema.json`>>._
@@ -100,7 +100,7 @@ A "Tree" class, which might describe a table of tree measurements taken in a par
 
 _Defined in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/Schema/class.property.schema.json[`class.property.schema.json`]._
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/Schema/class.property.schema.json[`class.property.schema.json`]._
 endif::[]
 ifndef::env-github[]
 <<reference-schema-class-property,`class.property.schema.json`>>._
@@ -160,7 +160,7 @@ A "Tree" class, which might describe a table of tree measurements taken in a par
 
 _Defined in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/Schema/enum.schema.json[`enum.schema.json`]._
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/Schema/enum.schema.json[`enum.schema.json`]._
 endif::[]
 ifndef::env-github[]
 <<reference-schema-enum,`enum.schema.json`>>._
@@ -202,7 +202,7 @@ A "Species" enum defining types of trees. An "Unspecified" enum value is optiona
 
 _Defined in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/Schema/enum.value.schema.json[`enum.value.schema.json`]._
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/Schema/enum.value.schema.json[`enum.value.schema.json`]._
 endif::[]
 ifndef::env-github[]
 <<reference-schema-enum-value,`enum.value.schema.json`>>._

--- a/specification/README.adoc
+++ b/specification/README.adoc
@@ -650,7 +650,7 @@ The `children` property is an array of objects that define child tiles. Each chi
 
 The full JSON schema can be found in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/tile.schema.json[`tile.schema.json`].
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/tile.schema.json[`tile.schema.json`].
 endif::[]
 ifndef::env-github[]
 <<reference-schema-tile,`tile.schema.json`>>.
@@ -974,7 +974,7 @@ While classes within a schema define the data types and meanings of properties, 
 
 The common structure of metadata entities that appear in a tileset is defined in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/metadataEntity.schema.json[`metadataEntity.schema.json`].
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/metadataEntity.schema.json[`metadataEntity.schema.json`].
 endif::[]
 ifndef::env-github[]
 <<reference-schema-metadataentity,`metadataEntity.schema.json`>>.
@@ -1014,7 +1014,7 @@ image::figures/3d-tiles-metadata-statistics.png[Metadata Granularity,600]
 
 The statistics are stored in the top-level `statistics` object of the tileset. The structure of this statistics object is defined in
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/Statistics/statistics.schema.json[`statistics.schema.json`].
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/Statistics/statistics.schema.json[`statistics.schema.json`].
 endif::[]
 ifndef::env-github[]
 <<reference-schema-statistics,`statistics.schema.json`>>.
@@ -1229,7 +1229,7 @@ The `extras` property allows application specific metadata to be added to any 3D
 
 The full JSON schema can be found in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/tileset.schema.json[`tileset.schema.json`].
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/tileset.schema.json[`tileset.schema.json`].
 endif::[]
 ifndef::env-github[]
 <<reference-schema-tileset,`tileset.schema.json`>>.

--- a/specification/TileFormats/Batched3DModel/README.adoc
+++ b/specification/TileFormats/Batched3DModel/README.adoc
@@ -100,7 +100,7 @@ More information is available in the xref:{url-specification-tileformats-feature
 
 The full JSON schema can be found in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/TileFormats/b3dm.featureTable.schema.json[`b3dm.featureTable.schema.json`].
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/TileFormats/b3dm.featureTable.schema.json[`b3dm.featureTable.schema.json`].
 endif::[]
 ifndef::env-github[]
 <<reference-schema-b3dm-featuretable,`b3dm.featureTable.schema.json`>>.

--- a/specification/TileFormats/Instanced3DModel/README.adoc
+++ b/specification/TileFormats/Instanced3DModel/README.adoc
@@ -115,7 +115,7 @@ More information is available in the xref:{url-specification-tileformats-feature
 
 The full JSON schema can be found in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/TileFormats/i3dm.featureTable.schema.json[`i3dm.featureTable.schema.json`].
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/TileFormats/i3dm.featureTable.schema.json[`i3dm.featureTable.schema.json`].
 endif::[]
 ifndef::env-github[]
 <<reference-schema-i3dm-featuretable,`i3dm.featureTable.schema.json`>>.

--- a/specification/TileFormats/PointCloud/README.adoc
+++ b/specification/TileFormats/PointCloud/README.adoc
@@ -97,7 +97,7 @@ More information is available in the xref:{url-specification-tileformats-feature
 
 The full JSON schema can be found in 
 ifdef::env-github[]
-link:https://github.com/CesiumGS/3d-tiles/tree/draft-1.1/specification/schema/TileFormats/pnts.featureTable.schema.json[`pnts.featureTable.schema.json`].
+link:https://github.com/CesiumGS/3d-tiles/tree/main/specification/schema/TileFormats/pnts.featureTable.schema.json[`pnts.featureTable.schema.json`].
 endif::[]
 ifndef::env-github[]
 <<reference-schema-pnts-featuretable,`pnts.featureTable.schema.json`>>.


### PR DESCRIPTION
Now that the `draft-1.1` branch is merged, some links should point to `main` instead.
