### PR TITLE
Implicit tiling clarifications

### DIFF
--- a/specification/ImplicitTiling/README.adoc
+++ b/specification/ImplicitTiling/README.adoc
@@ -452,9 +452,9 @@ The JSON description of a subtree where each tile is available, but not all tile
 
 The tile availability can be encoded by setting `tileAvailability.constant` to `1`, without needing an explicit bitstream, because all tiles in the subtree are available.
 
-Only some tiles have content, and `contentAvailability.bufferView` indicates where the bitstream for the content availability is stored: The `bufferView` with index 0 refers to the `buffer` with index 0. This buffer does not have a `uri` property, and therefore refers to the _internal_ buffer that is stored directly in the binary chunk of the subtree binary file. The `byteOffset` and `byteLength` indicate that the content availability bitstream is stored in the bytes `+[0...11)+` of the internal buffer.
+Only some tiles have content, and `contentAvailability.bitstream` is the index of the buffer view where the bitstream for the content availability is stored: The `bufferView` with index 0 refers to the `buffer` with index 0. This buffer does not have a `uri` property, and therefore refers to the _internal_ buffer that is stored directly in the binary chunk of the subtree binary file. The `byteOffset` and `byteLength` indicate that the content availability bitstream is stored in the bytes `+[0...11)+` of the internal buffer.
 
-Some child subtrees exist, so `childSubtreeAvailability.bufferView` refers to another bitstream. The `bufferView` with index 1 refers to the buffer with index `1`. This buffer has a `uri` property, indicating that this second bitstream is stored in an external binary file.
+Some child subtrees exist, so `childSubtreeAvailability.bitstream` is the index of a buffer view that contains another bitstream. The `bufferView` with index 1 refers to the buffer with index `1`. This buffer has a `uri` property, indicating that this second bitstream is stored in an external binary file.
 ====
 
 

--- a/specification/ImplicitTiling/README.adoc
+++ b/specification/ImplicitTiling/README.adoc
@@ -398,7 +398,7 @@ For efficient memory access, the `byteOffset` of a buffer view shall be aligned 
 
 Tile availability (`tileAvailability`) and child subtree availability (`childSubtreeAvailability`) shall always be provided for a subtree.
 
-Content availability (`contentAvailability`) is an array of content availability objects. If the implicit root tile has a single content this array will have one element; if the tile has multiple contents this array will have multiple elements. If the implicit root tile does not have content then `contentAvailability` shall be omitted.
+Content availability (`contentAvailability`) is an array of content availability objects. If the implicit root tile has a single `content`, then this array will have one element; if the tile has multiple `contents`, then this array will have multiple elements. If the implicit root tile does not have a `content` or `contents` property, and therefore does not define a content template URI, then this means that none of the implicit tiles has any content, and the `contentAvailability` in the subtrees shall be omitted.
 
 Availability may be represented either as a bitstream or a constant value. `bitstream` is an integer index that identifies the buffer view containing the availability bitstream. `constant` is an integer indicating whether all of the elements are available (`1`) or all are unavailable (`0`). `availableCount` is an integer indicating how many `1` bits exist in the availability bitstream.
 
@@ -462,7 +462,7 @@ Some child subtrees exist, so `childSubtreeAvailability.bitstream` is the index 
 [#implicittiling-metadata-1]
 === Metadata
 
-Subtrees may store metadata at multiple granularities. `tileMetadata` is a property table containing metadata for available tiles. `contentMetadata` is an array of property tables containing metadata for available content. If the implicit root tile has a single content this array will have one element; if the tile has multiple contents then this array will have multiple elements. If the implicit root tile does not have content then `contentMetadata` shall be omitted.
+Subtrees may store metadata at multiple granularities. `tileMetadata` is a property table containing metadata for available tiles. `contentMetadata` is an array of property tables containing metadata for available content. If the implicit root tile has a single `content`, then this array will have one element; if the tile has multiple `contents`, then this array will have multiple elements. If the implicit root tile does not have a `content` or `contents` property, then none of the implicit tiles has any content, and the `contentMetadata` shall be omitted.
 
 Subtree metadata (`subtreeMetadata`) is encoded in JSON according to the xref:{url-specification-metadata}README.adoc#metadata-json-format[JSON Format] specification.
 


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/3d-tiles/issues/766

The implementation notes used `contentAvailability.bufferView` where it should have been `contentAvailability.bitstream`. I think we went back and forth with the naming of `bufferView` and `bitstream` while writing this, and "bitstream" and "buffer view" are sometimes used interchangeably. I tried to adjust the wording to reduce the potential for confusion: The `contentAvailability.bitstream` is the _index of a buffer view_ (and this buffer view is/contains a bitstream).

Fixes https://github.com/CesiumGS/3d-tiles/issues/769

The main change here is that the word "content" is now differentiated more clearly to be "`content`" or "`contents`" when listing the cases. The issue originally only referred to the `contentAvailability`. But a similar (and similarly confusing) wording was used for the `contentMetadata`, so this is fixed here as well.

