### PR TITLE
Switch z and y semantics for implicitly tiled cylinders

### DIFF
--- a/extensions/3DTILES_bounding_volume_cylinder/README.md
+++ b/extensions/3DTILES_bounding_volume_cylinder/README.md
@@ -3,6 +3,7 @@
 ## Contributors
 
 - Sean Lilley, Cesium
+- Janine Liu, Cesium
 
 ## Status
 
@@ -49,7 +50,7 @@ Implicit tile coordinates:
 Coordinate|Positive Direction
 --|--
 x| From the center (increasing radius)
-y| From bottom to top (increasing height)
-z| From `-pi` to `pi` clockwise (see figure below)
+y| From `-pi` to `pi` clockwise (see figure below)
+z| From bottom to top (increasing height)
 
 ![Cylinder Coordinates](figures/cylinder-coordinates.png)


### PR DESCRIPTION
In `3DTILES_bounding_cylinder`, the schema says that implicitly tiled cylinders should use `y` to indicate changes in height, and `z` for angle. This felt inconsistent with how the height of the cylinder is aligned with the `z`-axis.

This PR just switches the two. (This will probably break existing tilesets, but hopefully any tilers out there can make an easy switch.)