### PR TITLE
Update `3DTILES_content_voxels` for coordinate system nuances

### DIFF
--- a/extensions/3DTILES_content_voxels/README.md
+++ b/extensions/3DTILES_content_voxels/README.md
@@ -103,9 +103,9 @@ These conventions align with how implicit tile coordinates defined in [Implicit 
 >
 > For **box** voxels, the grid's height corresponds to `y` in glTF, but must ultimately align with `z` in 3D Tiles. If the dimensions in `3DTILES_content_voxels` are `[width, height, depth]`, then the dimensions in `EXT_primitive_voxels` **MUST** be `[width, depth, height]`. Furthermore, if a **box** voxel is located at `[x, y, z]` within 3D Tiles, it refers to the voxel at `[x, depth-z, y]` in the glTF. 
 >
-> (From the glTF's perspective, if its dimensions are `[width, height, depth]`, then a box voxel at `[x, y, z]` will be located at `[x, z, height-y]` in 3D Tiles.)
+> (From the glTF's perspective, if its dimensions are `[width, height, depth]`, then a **box** voxel at `[x, y, z]` will be located at `[x, z, height-y]` in 3D Tiles.)
 > 
-> For **cylinder** voxels, the cylinder's height corresponds to `y` in glTF but `z` in 3D Tiles. If the dimensions in `3DTILES_content_voxels` are `[radius, angle, height]`, then the dimensions in `EXT_primitive_voxels` **MUST** be `[radius, height, angle]`. 
+> For **cylinder** voxels, the grid's height corresponds to `y` in glTF but `z` in 3D Tiles. If the dimensions in `3DTILES_content_voxels` are `[radius, angle, height]`, then the dimensions in `EXT_primitive_voxels` **MUST** be `[radius, height, angle]`. The start of the cylinder's angular data is also affected due to the differing orientations. A **cylinder** voxel at `[x, y, z]` within 3D Tiles is located at `[x, z, a]` in the glTF where `a = [y + (angle / 2)] % angle`. The math is the same vice versa.
 > 
 > The data order of **ellipsoid** voxels is the same between glTF and 3D Tiles. In this case, the `dimensions` in `EXT_primitive_voxels` **MUST** be equal to those in `3DTILES_content_voxels`.
 > 

--- a/extensions/3DTILES_content_voxels/README.md
+++ b/extensions/3DTILES_content_voxels/README.md
@@ -99,17 +99,15 @@ These conventions align with how implicit tile coordinates defined in [Implicit 
 | ------------- | ------------- | ------------- |
 |![Box Voxel Grid](figures/box.png)|![Region Voxel Grid](figures/sphere.png)|![Cylinder Voxel Grid](figures/cylinder.png)|
 
-> **Implementation Note**: glTF and 3D Tiles use different up-axes, which results in different expectations for voxel **data order**. Although both use an `[x, y, z]` ordering, the meanings of the `y` and `z` axes are not one-to-one for **box** or **cylinder** voxels.
+> **Implementation Note**: glTF and 3D Tiles use different up-axes, which results in different expectations for voxel **data order**. Although both use an `[x, y, z]` ordering, the meanings of the `y` and `z` axes are not one-to-one for **box** or **cylinder** voxels. Although the glTFs will be transformed from `y`-up to `z`-up at runtime, the data itself must be accessed in a non-linear fashion to reflect the transform.
 >
-> For **box** voxels, the grid's height corresponds to `y` in glTF, but must ultimately align with `z` in 3D Tiles. If the dimensions in `3DTILES_content_voxels` are `[width, height, depth]`, then the dimensions in `EXT_primitive_voxels` **MUST** be `[width, depth, height]`. Furthermore, if a **box** voxel is located at `[x, y, z]` within 3D Tiles, it refers to the voxel at `[x, depth-z, y]` in the glTF. 
+> For **box** voxels, the grid's height corresponds to `y` in glTF, but must ultimately align with `z` in 3D Tiles. If the dimensions in `3DTILES_content_voxels` are `[width, height, depth]`, then the dimensions in `EXT_primitive_voxels` **MUST** be `[width, depth, height]`. Furthermore, if a **box** voxel is located at `[x, y, z]` within 3D Tiles, it refers to the voxel at `[x, (depth - 1) - z, y]` in the glTF. 
 >
-> (From the glTF's perspective, if its dimensions are `[width, height, depth]`, then a **box** voxel at `[x, y, z]` will be located at `[x, z, height-y]` in 3D Tiles.)
+> (From the glTF's perspective, if its dimensions are `[width, height, depth]`, then a **box** voxel at `[x, y, z]` will be located at `[x, z, (height - 1) - y]` in 3D Tiles.)
 > 
 > For **cylinder** voxels, the grid's height corresponds to `y` in glTF but `z` in 3D Tiles. If the dimensions in `3DTILES_content_voxels` are `[radius, angle, height]`, then the dimensions in `EXT_primitive_voxels` **MUST** be `[radius, height, angle]`. The start of the cylinder's angular data is also affected due to the differing orientations. A **cylinder** voxel at `[x, y, z]` within 3D Tiles is located at `[x, z, a]` in the glTF where `a = [y + (angle / 2)] % angle`. The math is the same vice versa.
 > 
 > The data order of **ellipsoid** voxels is the same between glTF and 3D Tiles. In this case, the `dimensions` in `EXT_primitive_voxels` **MUST** be equal to those in `3DTILES_content_voxels`.
-> 
-> Finally, glTFs with `EXT_primitive_voxels` should contain a `z`-up-to-`y`-up transform via `node.matrix` to account for how they are be transformed at runtime to be brought into the 3D Tiles frame of reference (`y`-up-to-`z`-up). The non-linear access of the voxel data essentially reflects that `y`-up-to-`z`-up transform.
 
 #### Padding
 

--- a/extensions/3DTILES_content_voxels/README.md
+++ b/extensions/3DTILES_content_voxels/README.md
@@ -26,7 +26,7 @@ This extension is often paired with [Implicit Tiling](../../specification/Implic
 
 ### Content Extension
 
-The `content` extension describes the structure of the voxel grid.
+The `content` extension describes the structure of the voxel grid that the `content` object contains.
 
 ```json
 "content": {
@@ -65,7 +65,7 @@ The bounding volume **MUST** match the type of `shape` used for the glTF voxel g
 
 #### Dimensions
 
-The `dimensions` property of the extension specifies the grid dimensions for each axis. The value **MUST** match the `dimensions` specified in the `EXT_primitive_voxels` extension on the glTF voxel grids. The axis order and coordinate conventions are described below.
+The `dimensions` property of the extension specifies the voxel grid's dimensions along each axis. Dimensions must be nonzero, and elements must be laid out on a first-axis continguous basis. The meaning of each "axis" depends on the voxel grid's shape, explained below.
 
 For `box` bounding volumes:
 
@@ -93,13 +93,23 @@ Axis|Coordinate|Positive Direction
 
 ![Cylinder Coordinates](figures/cylinder-coordinates.png)
 
-The figure below shows `"dimensions": [8, 8, 8]` for each shape type:
+These conventions align with how implicit tile coordinates defined in [Implicit Tiling](../../specification/ImplicitTiling/). The figure below shows `"dimensions": [8, 8, 8]` for each shape type:
 
 |Box|Region|Cylinder|
 | ------------- | ------------- | ------------- |
 |![Box Voxel Grid](figures/box.png)|![Region Voxel Grid](figures/sphere.png)|![Cylinder Voxel Grid](figures/cylinder.png)|
 
-Dimensions must be nonzero. Elements are laid out in memory first-axis-contiguous, e.g. for boxes, x data is contiguous.
+> **Implementation Note**: glTF and 3D Tiles use different up-axes, which results in different expectations for voxel **data order**. Although both use an `[x, y, z]` ordering, the meanings of the `y` and `z` axes are not one-to-one for **box** or **cylinder** voxels.
+>
+> For **box** voxels, the grid's height corresponds to `y` in glTF, but must ultimately align with `z` in 3D Tiles. If the dimensions in `3DTILES_content_voxels` are `[width, height, depth]`, then the dimensions in `EXT_primitive_voxels` **MUST** be `[width, depth, height]`. Furthermore, if a **box** voxel is located at `[x, y, z]` within 3D Tiles, it refers to the voxel at `[x, depth-z, y]` in the glTF. 
+>
+> (From the glTF's perspective, if its dimensions are `[width, height, depth]`, then a box voxel at `[x, y, z]` will be located at `[x, z, height-y]` in 3D Tiles.)
+> 
+> For **cylinder** voxels, the cylinder's height corresponds to `y` in glTF but `z` in 3D Tiles. If the dimensions in `3DTILES_content_voxels` are `[radius, angle, height]`, then the dimensions in `EXT_primitive_voxels` **MUST** be `[radius, height, angle]`. 
+> 
+> The data order of **ellipsoid** voxels is the same between glTF and 3D Tiles. In this case, the `dimensions` in `EXT_primitive_voxels` **MUST** be equal to those in `3DTILES_content_voxels`.
+> 
+> Finally, glTFs with `EXT_primitive_voxels` should contain a `z`-up-to-`y`-up transform via `node.matrix` to account for how they are be transformed at runtime to be brought into the 3D Tiles frame of reference (`y`-up-to-`z`-up). The non-linear access of the voxel data essentially reflects that `y`-up-to-`z`-up transform.
 
 #### Padding
 


### PR DESCRIPTION
This adds implementation notes in the README for `3DTILES_content_voxels` about the differing coordinate systems in glTF / 3D Tiles. The difference causes data to be misaligned between the two specs, so the note points this out and provides math for the correct access of data, depending on the frame of reference.