### PR TITLE
Un-deprecate `3DTILES_content_gltf`

### DIFF
--- a/extensions/3DTILES_content_gltf/README.md
+++ b/extensions/3DTILES_content_gltf/README.md
@@ -1,5 +1,3 @@
-### ⚠️ `3DTILES_content_gltf` has been promoted to core in 3D Tiles 1.1. See [glTF Tile Format](../../specification/TileFormats/glTF/). ⚠️
-
 # 3DTILES_content_gltf
 
 ## Contributors
@@ -16,23 +14,27 @@ Complete
 
 ## Dependencies
 
-Written against the 3D Tiles 1.0 specification.
+Written against the 3D Tiles 1.0 and 3D Tiles 1.1 specifications.
 
 ## Optional vs. Required
 
-This extension is required, meaning it must be placed in both the `extensionsUsed` and `extensionsRequired` lists in the tileset JSON.
+For a 3D Tiles 1.0 tileset that uses glTF content, this this extension is required, meaning it must be placed in both the `extensionsUsed` and `extensionsRequired` lists in the tileset JSON.
+
+For a 3D Tiles 1.1 tileset, this extension is optional, meaning that it can be placed in the `extensionsUsed` list of the tileset JSON.
 
 ## Overview
 
-This extension allows a tileset to use [glTF 2.0](https://github.com/KhronosGroup/glTF/tree/main/specification/2.0) assets directly as tile content. Both `glTF` JSON and `GLB` binary formats are supported.
+This extension allows a 3D Tiles 1.0 tileset to use [glTF 2.0](https://github.com/KhronosGroup/glTF/tree/main/specification/2.0) assets directly as tile content. Both `glTF` JSON and `GLB` binary formats are supported.
 
 Using glTF as a tile format simplifies content pipelines from creation to runtime. This allows greater compatibility with existing tools (e.g. 3D modeling software, validators, optimizers) that create or process glTF assets. Runtime engines that currently support glTF can more easily support 3D Tiles. In many cases, existing tile formats can be converted into the corresponding glTF content, as described in the [Migration Guide](../specification/TileFormats/../../../specification/TileFormats/glTF/MIGRATION.adoc).
+
+For both 3D Tiles 1.0 and 1.1, this extension allows specifying the extensions that are used and required by the glTF content that the tileset refers to.
 
 ## Extension JSON
 
 *Defined in [tileset.3DTILES_content_gltf.schema.json](./schema/tileset.3DTILES_content_gltf.schema.json).*
 
-With this extension, the tile content may be a glTF asset. Runtime engines must be able to determine compatibility before loading the content. If the glTF asset uses or requires certain glTF extensions, then these extensions must also be listed in the `3DTILES_content_gltf` object. This is a property of the top-level tileset `extensions` object with the following properties:
+When a tileset refers to glTF content, then runtime engines must be able to determine compatibility before loading the content. If the glTF asset uses or requires certain glTF extensions, then these extensions must also be listed in the `3DTILES_content_gltf` object. This is a property of the top-level tileset `extensions` object with the following properties:
 
 * `extensionsUsed`: an array of glTF extensions used by any glTF content in the tileset.
 * `extensionsRequired`: an array of glTF extensions required by any glTF content in the tileset.

--- a/extensions/3DTILES_content_gltf/schema/tileset.3DTILES_content_gltf.schema.json
+++ b/extensions/3DTILES_content_gltf/schema/tileset.3DTILES_content_gltf.schema.json
@@ -3,7 +3,7 @@
     "$id": "tileset.3DTILES_content_gltf.schema.json",
     "title": "3DTILES_content_gltf extension",
     "$ref": "rootProperty.schema.json",
-    "description": "3D Tiles extension that allows a tileset to use glTF models directly as tile content.",
+    "description": "3D Tiles extension that allows a 3D Tiles 1.0 tileset to use glTF models directly as tile content. For 3D Tiles 1.0 and 3D Tiles 1.1, it allows to specify the extensions that are used and required by the glTF content.",
     "properties": {
         "extensionsUsed": {
             "type": "array",


### PR DESCRIPTION

The [`3DTILES_content_gltf`](https://github.com/CesiumGS/3d-tiles/blob/e57f89c1ab779f38492a7fa1ef89be161474d118/extensions/3DTILES_content_gltf/README.md) extension originally had the purpose of allowing 3D Tiles 1.0 tilesets to directly contain glTF assets as the tile content.

When support for glTF tile content became part of the core specification in 3D Tiles 1.1, this extension was deprecated.

But in addition to just allowing glTF tile content, the extension also served another purpose - namely, to allow specifying the `extensionsUsed/Required` _of the glTF content(!)_ inside the tileset JSON. This is important for clients, to determine early whether they will be able to load/process a tileset, _without_ having to inspect each tile content, and possibly reject it as they load it.

There is no strong reason to not allow the extension being present in a 3D Tiles 1.1 tileset for this exact purpose.

So this PR un-deprecates the extension. Minor wording updates in the README.md aim at clarifying the different roles that the extension has in 3D Tiles 1.0 and 1.1.

This is one tiny part of https://github.com/CesiumGS/3d-tiles/issues/701 , I'll add another comment there.

---

<sup>(Searching for the "opposite of 'deprecate'" brought up 'praise' - hence the branch name)</sup>
