### PR TITLE
Asset Schema: Add support for "generator" field

### DIFF
--- a/specification/schema/asset.schema.json
+++ b/specification/schema/asset.schema.json
@@ -5,6 +5,14 @@
     "$ref": "./common/rootProperty.schema.json",
     "description": "Metadata about the entire tileset.",
     "properties": {
+        "generator": {
+            "type": "string",
+            "description": "Tool that generated this 3D Tiles model.  Useful for debugging."
+        },
+        "generatorVersion": {
+            "type": "string",
+            "description": "The version of the tool that generated this 3D Tiles model.  Useful for debugging."
+        },
         "version": {
             "type": "string",
             "description": "The 3D Tiles version. The version defines the JSON schema for the tileset JSON and the base set of tile formats."

--- a/specification/schema/asset.schema.json
+++ b/specification/schema/asset.schema.json
@@ -7,11 +7,7 @@
     "properties": {
         "generator": {
             "type": "string",
-            "description": "Tool that generated this 3D Tiles model.  Useful for debugging."
-        },
-        "generatorVersion": {
-            "type": "string",
-            "description": "The version of the tool that generated this 3D Tiles model.  Useful for debugging."
+            "description": "The name and version number of the tool that generated this 3D Tiles model.  Useful for debugging."
         },
         "version": {
             "type": "string",


### PR DESCRIPTION
As discussed in #813. Adds optional "generator" and "generatorVersion" fields, [similar to the glTF schema](https://github.com/KhronosGroup/glTF/blob/90139f8f126c222a4b684219f226f85004ad45fc/specification/2.0/schema/asset.schema.json#L13-L16), so asset sources and potential generation issues can be appropriately handled and reported.