### PR TITLE
Clarify requirements for `3DTILES_content_gltf`

### DIFF
--- a/extensions/3DTILES_content_gltf/README.md
+++ b/extensions/3DTILES_content_gltf/README.md
@@ -20,7 +20,7 @@ Written against the 3D Tiles 1.0 and 3D Tiles 1.1 specifications.
 
 For a 3D Tiles 1.0 tileset that uses glTF content, this this extension is required, meaning it must be placed in both the `extensionsUsed` and `extensionsRequired` lists in the tileset JSON.
 
-For a 3D Tiles 1.1 tileset, this extension is optional, meaning that it can be placed in the `extensionsUsed` list of the tileset JSON.
+For a 3D Tiles 1.1 tileset, this extension is optional. A 3D Tiles 1.1 tileset can use glTF content without declaring this extension in its `extensionsUsed` list. _Only_ when the extension JSON object (as defined below) is used, then the extension must be placed in the `extensionsUsed` list of the tileset JSON. It may never be placed in the `extensionsRequired` list of a 3D Tiles 1.1 tileset.
 
 ## Overview
 
@@ -28,18 +28,21 @@ This extension allows a 3D Tiles 1.0 tileset to use [glTF 2.0](https://github.co
 
 Using glTF as a tile format simplifies content pipelines from creation to runtime. This allows greater compatibility with existing tools (e.g. 3D modeling software, validators, optimizers) that create or process glTF assets. Runtime engines that currently support glTF can more easily support 3D Tiles. In many cases, existing tile formats can be converted into the corresponding glTF content, as described in the [Migration Guide](../specification/TileFormats/../../../specification/TileFormats/glTF/MIGRATION.adoc).
 
-For both 3D Tiles 1.0 and 1.1, this extension allows specifying the extensions that are used and required by the glTF content that the tileset refers to.
+For both 3D Tiles 1.0 and 1.1, this extension allows specifying the extensions that are used and required by the glTF content that the tileset refers to. This allows runtime engines to determine compatibility immediately after loading the tileset JSON, but before loading the content.
 
 ## Extension JSON
 
 *Defined in [tileset.3DTILES_content_gltf.schema.json](./schema/tileset.3DTILES_content_gltf.schema.json).*
 
-When a tileset refers to glTF content, then runtime engines must be able to determine compatibility before loading the content. If the glTF asset uses or requires certain glTF extensions, then these extensions must also be listed in the `3DTILES_content_gltf` object. This is a property of the top-level tileset `extensions` object with the following properties:
+The `3DTILES_content_gltf` object is a property of the top-level tileset `extensions` object. When it is defined, then it must list all extensions that are used or required by any glTF content that the tileset refers to, using the following properties:
 
 * `extensionsUsed`: an array of glTF extensions used by any glTF content in the tileset.
 * `extensionsRequired`: an array of glTF extensions required by any glTF content in the tileset.
 
-> **Example:** A tileset that uses the `3DTILES_content_gltf` extension to directly refer to a glTF asset in the content of the root tile. The glTF asset in turn requires the `EXT_mesh_gpu_instancing` extension.
+
+## Examples
+
+> **Example:** A 3D Tiles 1.0 tileset that uses glTF content in the root tile. It must declare the `3DTILES_content_gltf` extension in its `extensionsUsed` and `extensionsRequired` list, to indicate the use of glTF in a 3D Tiles 1.0 tileset. In this example, the glTF content does not use or require any glTF extensions, meaning that the `3DTILES_content_gltf` extension JSON object is not defined here. 
 > 
 > ```json
 > {
@@ -48,6 +51,36 @@ When a tileset refers to glTF content, then runtime engines must be able to dete
 >   },
 >   "extensionsUsed": ["3DTILES_content_gltf"],
 >   "extensionsRequired": ["3DTILES_content_gltf"],
+>   "geometricError": 240,
+>   "root": {
+>     "boundingVolume": {
+>       "region": [
+>         -1.3197209591796106,
+>         0.6988424218,
+>         -1.3196390408203893,
+>         0.6989055782,
+>         0,
+>         88
+>       ]
+>     },
+>     "geometricError": 0,
+>     "refine": "ADD",
+>     "content": {
+>       "uri": "content.gltf"
+>     }
+>   }
+> }
+> ```
+
+
+> **Example:** A 3D Tiles 1.1 tileset that uses the `3DTILES_content_gltf` extension. In this example, the glTF content uses (and requires) the  `EXT_mesh_gpu_instancing` extension. The `3DTILES_content_gltf` extension JSON is used to define the glTF extensions that are used and required by the glTF content.
+> 
+> ```json
+> {
+>   "asset": {
+>     "version": "1.1"
+>   },
+>   "extensionsUsed": ["3DTILES_content_gltf"],
 >   "extensions": {
 >     "3DTILES_content_gltf": {
 >       "extensionsUsed": ["EXT_mesh_gpu_instancing"],
@@ -69,7 +102,7 @@ When a tileset refers to glTF content, then runtime engines must be able to dete
 >     "geometricError": 0,
 >     "refine": "ADD",
 >     "content": {
->       "uri": "trees.gltf"
+>       "uri": "treeInstances.gltf"
 >     }
 >   }
 > }

--- a/extensions/3DTILES_content_gltf/README.md
+++ b/extensions/3DTILES_content_gltf/README.md
@@ -28,7 +28,7 @@ This extension allows a 3D Tiles 1.0 tileset to use [glTF 2.0](https://github.co
 
 Using glTF as a tile format simplifies content pipelines from creation to runtime. This allows greater compatibility with existing tools (e.g. 3D modeling software, validators, optimizers) that create or process glTF assets. Runtime engines that currently support glTF can more easily support 3D Tiles. In many cases, existing tile formats can be converted into the corresponding glTF content, as described in the [Migration Guide](../specification/TileFormats/../../../specification/TileFormats/glTF/MIGRATION.adoc).
 
-For both 3D Tiles 1.0 and 1.1, this extension allows specifying the extensions that are used and required by the glTF content that the tileset refers to. This allows runtime engines to determine compatibility immediately after loading the tileset JSON, but before loading the content.
+For both 3D Tiles 1.0 and 1.1, this extension allows specifying the extensions that are used and required by any glTF content that the tileset refers to. This allows runtime engines to determine compatibility immediately after loading the tileset JSON, but before loading the content.
 
 ## Extension JSON
 

--- a/extensions/3DTILES_content_gltf/README.md
+++ b/extensions/3DTILES_content_gltf/README.md
@@ -73,7 +73,7 @@ The `3DTILES_content_gltf` object is a property of the top-level tileset `extens
 > ```
 
 
-> **Example:** A 3D Tiles 1.1 tileset that uses the `3DTILES_content_gltf` extension. In this example, the glTF content uses (and requires) the  `EXT_mesh_gpu_instancing` extension. The `3DTILES_content_gltf` extension JSON is used to define the glTF extensions that are used and required by the glTF content.
+> **Example:** A 3D Tiles 1.1 tileset that uses glTF content directly. In this example, the glTF content uses (and requires) the `EXT_mesh_gpu_instancing extension`. While the `3DTILES_content_gltf` extension is not required in 3D Tiles 1.1 (as glTF support is now core), including it helps runtime engines determine compatibility before loading content. The extension's JSON properties declare which glTF extensions are used and required by any glTF content in the tileset.
 > 
 > ```json
 > {


### PR DESCRIPTION
Based on a discussion at https://github.com/CesiumGS/3d-tiles-validator/issues/349 , this attempts to clarify the exact conditions under which the `3DTILES_content_gltf` extension has to be listed in `extensionsUsed`/`extensionsRequired`, for 3D Tiles 1.0 and 3D Tiles 1.1.

