### PR TITLE
Added ESRI_crs to the list of extensions

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -30,7 +30,7 @@ Extension|Notes
 [MAXAR_content_geojson](https://github.com/Maxar-Public/3d-tiles/tree/wff1.7.0/extensions/MAXAR_content_geojson)|_Written against 3D Tiles 1.1_
 [MAXAR_extent](https://github.com/Maxar-Public/3d-tiles/tree/wff1.7.0/extensions/MAXAR_extent)|_Written against 3D Tiles 1.0 and 1.1_
 [VRICON_class](https://github.com/Maxar-Public/3d-tiles/tree/wff1.7.0/extensions/VRICON_class)|_Written against 3D Tiles 1.0_
-
+[ESRI_crs](https://github.com/Esri/3D-tiles-layer/blob/main/ESRI_CRS/Esri_crs_extension.md)|_Written against 3D Tiles 1.1_
 
 ## About
 


### PR DESCRIPTION
This extension was introduced to handle projected coordinates in 3D tilesets of gaussian splats, without client-side reprojection. It's supported by ArcGIS Pro 3.6 and the associated Esri products (ArcGIS Reality Studio, ArcGIS Drone2Map), released in November 2025. It will also be supported by ArcGIS Online 2026 R1.
In the future, we ambition to also use this extension for the 3D Meshes produced by Esri's Reality Mapping products.
Please refer to the specs of the vendor extension for more detail.